### PR TITLE
fix(ci): gate iOS release automation on successful Analyze

### DIFF
--- a/.github/workflows/auto-tag-ios-release.yml
+++ b/.github/workflows/auto-tag-ios-release.yml
@@ -1,9 +1,11 @@
 name: Auto Tag iOS Release
 
 on:
-  pull_request_target:
+  workflow_run:
+    workflows:
+      - Analyze
     types:
-      - closed
+      - completed
 
 permissions:
   actions: write
@@ -20,30 +22,45 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: >
-      github.event.pull_request.merged == true &&
-      (github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'master') &&
-      (
-        contains(github.event.pull_request.labels.*.name, 'ios:release:patch') ||
-        contains(github.event.pull_request.labels.*.name, 'ios:release:minor') ||
-        contains(github.event.pull_request.labels.*.name, 'ios:release:major')
-      )
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'master' &&
+      github.event.workflow_run.conclusion == 'success'
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Determine next release tag
         id: next-tag
         shell: bash
         env:
-          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
 
-          mapfile -t release_labels < <(jq -r '.[] | select(test("^ios:release:(patch|minor|major)$"))' <<< "$PR_LABELS_JSON")
+          pull_request="$(
+            gh api "/repos/${{ github.repository }}/commits/$TARGET_SHA/pulls" \
+              --jq "map(select(.merge_commit_sha == \"$TARGET_SHA\" and .base.ref == \"master\")) | .[0] // empty"
+          )"
+
+          if [[ -z "$pull_request" ]]; then
+            echo "No merged PR found for analyzed SHA $TARGET_SHA; skipping release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mapfile -t release_labels < <(jq -r '.labels[].name | select(test("^ios:release:(patch|minor|major)$"))' <<< "$pull_request")
           release_label_count="${#release_labels[@]}"
+
+          if [[ "$release_label_count" -eq 0 ]]; then
+            echo "Merged PR has no iOS release label; skipping release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [[ "$release_label_count" -ne 1 ]]; then
             echo "Expected exactly one iOS release label, found $release_label_count:"
@@ -56,26 +73,52 @@ jobs:
 
           git fetch --force --tags origin
 
-          latest_tag="$(
+          mapfile -t release_tags < <(
             git tag --list 'ios-v*' |
               grep -E '^ios-v[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+$' |
-              sed -E 's/^ios-v//' |
-              sort -V |
-              tail -n 1 ||
+              sort -V ||
               true
-          )"
+          )
+          release_tag_count="${#release_tags[@]}"
 
-          if [[ -z "$latest_tag" ]]; then
+          existing_release_tag=""
+          for release_tag in "${release_tags[@]}"; do
+            release_tag_sha="$(git rev-list -n 1 "refs/tags/$release_tag")"
+            if [[ "$release_tag_sha" == "$TARGET_SHA" ]]; then
+              existing_release_tag="$release_tag"
+            fi
+          done
+
+          if [[ -n "$existing_release_tag" ]]; then
+            echo "Analyzed SHA is already tagged as $existing_release_tag; skipping release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$release_tag_count" -eq 0 ]]; then
             major=0
             minor=0
             patch=0
-          elif [[ "$latest_tag" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)\+([0-9]+)$ ]]; then
+          else
+            latest_release_tag="${release_tags[$((release_tag_count - 1))]}"
+            latest_tag="${latest_release_tag#ios-v}"
+            latest_release_sha="$(git rev-list -n 1 "refs/tags/$latest_release_tag")"
+
+            if ! git merge-base --is-ancestor "$latest_release_sha" "$TARGET_SHA"; then
+              echo "Latest release $latest_release_tag points to $latest_release_sha,"
+              echo "which is not an ancestor of analyzed SHA $TARGET_SHA."
+              echo "Refusing to publish older history as a newer version."
+              exit 1
+            fi
+
+            if [[ ! "$latest_tag" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)\+([0-9]+)$ ]]; then
+              echo "Could not parse latest iOS release tag: $latest_release_tag"
+              exit 1
+            fi
+
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
             patch="${BASH_REMATCH[3]}"
-          else
-            echo "Could not parse latest iOS release tag: ios-v$latest_tag"
-            exit 1
           fi
 
           case "$bump" in
@@ -107,21 +150,22 @@ jobs:
 
           {
             echo "bump=$bump"
+            echo "release=true"
             echo "tag=$next_tag"
           } >> "$GITHUB_OUTPUT"
 
       - name: Create and push release tag
+        if: steps.next-tag.outputs.release == 'true'
         shell: bash
         env:
           NEXT_TAG: ${{ steps.next-tag.outputs.tag }}
-          TARGET_SHA: ${{ github.event.pull_request.merge_commit_sha }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
+          BASE_REF: master
         run: |
           set -euo pipefail
 
           if [[ -z "$TARGET_SHA" || "$TARGET_SHA" == "null" ]]; then
-            echo "Missing merged result SHA for PR #$PR_NUMBER"
+            echo "Missing analyzed SHA."
             exit 1
           fi
 
@@ -136,11 +180,12 @@ jobs:
           git push origin "refs/tags/$NEXT_TAG"
 
       - name: Dispatch iOS release workflow
+        if: steps.next-tag.outputs.release == 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           NEXT_TAG: ${{ steps.next-tag.outputs.tag }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_REF: master
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/.github/workflows/dispatch-ios-release.yml
+++ b/.github/workflows/dispatch-ios-release.yml
@@ -12,6 +12,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -71,6 +72,44 @@ jobs:
             echo "BUILD_NUMBER=$BUILD_NUMBER"
             echo "TAG_SHA=$TAG_SHA"
           } >> "$GITHUB_ENV"
+
+      - name: Require successful Analyze for release SHA
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          analyze_runs="$(
+            gh api --method GET \
+              "/repos/$REPOSITORY/actions/workflows/analyze.yml/runs" \
+              -f event=push \
+              -f status=success \
+              -f head_sha="$TAG_SHA" \
+              -f per_page=100
+          )"
+
+          matching_run="$(
+            jq -r \
+              --arg sha "$TAG_SHA" \
+              '.workflow_runs
+               | map(select(
+                   .event == "push" and
+                   .head_branch == "master" and
+                   .head_sha == $sha and
+                   .conclusion == "success"
+                 ))
+               | first
+               | .html_url // empty' <<< "$analyze_runs"
+          )"
+
+          if [[ -z "$matching_run" ]]; then
+            echo "No successful master Analyze run found for release SHA: $TAG_SHA"
+            exit 1
+          fi
+
+          echo "Using Analyze result: $matching_run"
 
       - name: Create GitHub App installation token
         id: app-token


### PR DESCRIPTION
## 背景

原来的 iOS 自动发布流程监听 PR 合并事件：

```text
PR 合并 + ios:release:* Label
→ 创建 Git Tag
→ 派遣私有仓库构建签名 IPA
```

该流程不会等待合并提交在 `master` 上的 `flutter analyze` 完成。

此前 PR #71 合并后，自动流程创建了 `ios-v0.4.0+1`，但代码中的 `TargetPlatform.ohos` 随后导致 Analyze 和 iOS 构建失败。核心问题：CI 尚未通过，发布流程已经开始。

## 修改目标

- PR 合并后，等待 `master` 对应提交的 Analyze 完成。
- Analyze 失败：不创建 Tag、不构建 IPA。
- Analyze 成功：继续检查 `ios:release:*` Label。
- 复用准确 Commit SHA 已有的 Analyze 结果，不重复执行 `flutter analyze`。
- 手动创建的 iOS Tag 同样不能绕过 Analyze。
- 防止同一 SHA 重复发版，以及旧 SHA 被标记成更高版本。

## 修改内容

### `Auto Tag iOS Release`

触发条件从：

```text
pull_request_target: closed
```

改为：

```text
Analyze workflow_run: completed
```

仅在以下条件全部成立时继续：

```text
event == push
head_branch == master
conclusion == success
```

随后：

1. 使用 Analyze 的准确 `head_sha`。
2. 查询该 SHA 对应的已合并 PR。
3. 检查 PR 是否恰好具有一个 `ios:release:patch/minor/major` Label。
4. 没有发布 Label：正常跳过。
5. 同一 SHA 已存在合法 iOS Tag：跳过，防止重复发布。
6. 最新发布 Tag 不是目标 SHA 的祖先：拒绝发布，防止旧代码获得更高版本号。
7. 创建 Tag 后显式调用 `Dispatch iOS Release`。

### `Dispatch iOS Release`

派遣私有签名仓库前增加 Analyze 门禁：

1. 解析 Git Tag 对应的准确 `TAG_SHA`。
2. 查询 `analyze.yml` 已有的 Workflow Runs。
3. 仅接受同时满足以下条件的结果：

```text
event == push
head_branch == master
head_sha == TAG_SHA
conclusion == success
```

找不到对应结果：拒绝派遣私有仓库。

该步骤只查询已有 CI 结果，不会重新运行 `flutter analyze`。

## 最终流程

```text
PR 更新
└─ Analyze：检查 PR

PR 合并到 master
└─ Analyze：检查实际合并 SHA
   ├─ failure：结束
   └─ success
      └─ Auto Tag
         ├─ 无 ios:release:* Label：结束
         └─ 有发布 Label
            ├─ 创建 Git Tag
            └─ Dispatch
               ├─ 再次核对该 Tag SHA 已有的 Analyze 结果
               └─ 通知私有仓库签名 IPA、上传 TestFlight
```

## 验证

- 三段 Bash 脚本语法检查通过。
- 新 SHA：正常计算下一版本。
- 已打 Tag 的 SHA：正常跳过。
- 比最新发布版本更旧的 SHA：拒绝发布。
- `git diff --check` 通过。
- Commit GPG 签名验证通过。
- 私有 `TechPie-release` 仓库未修改。

尚未验证：真实 GitHub Actions 端到端运行。`workflow_run` 必须进入默认分支后才能进行真实验证。

## 请重点 Review

1. `workflow_run` 的触发条件是否正确。
2. `head_sha` 是否始终对应准备发布的准确提交。
3. Commit 与已合并 PR、PR Label 的关联逻辑是否可靠。
4. 同一 SHA 的幂等处理是否合理。
5. 多个 Analyze 乱序完成时，祖先检查是否足够。
6. Workflow Runs API 对 `TAG_SHA` 的过滤是否正确。
7. `actions: read/write`、`contents: write` 权限是否合理。
8. 使用 `GITHUB_TOKEN` 创建 Tag 后，再显式调用 `workflow_dispatch` 的逻辑是否正确。
9. Tag 已创建但 Dispatch 失败时的恢复方式是否可接受。

## 合并后预期行为

```text
master Analyze 成功
→ Auto Tag 启动
→ 检查到本 PR 没有发布 Label
→ 正常跳过
→ 不创建 Git Tag
→ 不调用私有签名仓库
```