### PR TITLE
fix(auth): keep login failures inline and cover callback parsing

### DIFF
--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -9,7 +9,6 @@ import '../services/service_provider.dart';
 import '../services/uni_auth_service.dart';
 import '../utils/platform.dart';
 import '../widgets/adaptive_button.dart';
-import '../widgets/adaptive_feedback.dart';
 import '../widgets/adaptive_page_navigation.dart';
 import '../widgets/ios/ios_native_navigation_bar.dart';
 
@@ -127,15 +126,7 @@ class _LoginPageState extends State<LoginPage> {
       }
     } catch (e) {
       if (mounted) {
-        if (isIos()) {
-          setState(() => _inlineMessage = '登录失败：$e');
-        } else {
-          showAdaptiveFeedback(
-            context: context,
-            message: '登录失败: $e',
-            style: AdaptiveFeedbackStyle.error,
-          );
-        }
+        setState(() => _inlineMessage = '登录失败：$e');
       }
     } finally {
       if (mounted) setState(() => _loading = false);

--- a/lib/services/uni_auth_service.dart
+++ b/lib/services/uni_auth_service.dart
@@ -84,7 +84,7 @@ class UniAuthService extends ChangeNotifier {
       } else {
         callbackUrl = await casdoor.showFullscreen(context);
       }
-      final code = _extractCode(callbackUrl);
+      final code = extractUniAuthCallbackCode(callbackUrl);
       if (code.isEmpty) {
         throw Exception('Login cancelled or failed');
       }
@@ -103,7 +103,7 @@ class UniAuthService extends ChangeNotifier {
     try {
       final casdoor = _getCasdoor();
       final callbackUrl = await casdoor.show();
-      final code = _extractCode(callbackUrl);
+      final code = extractUniAuthCallbackCode(callbackUrl);
       if (code.isEmpty) {
         throw Exception('Login cancelled or failed');
       }
@@ -170,16 +170,6 @@ class UniAuthService extends ChangeNotifier {
     );
   }
 
-  /// Pull the `code` query parameter out of the callback URL the SDK returns.
-  /// casdoor.showFullscreen / casdoor.show yield the full redirect URL
-  /// (e.g. `techpie://auth-callback?code=xxx&state=yyy`), not just the code.
-  String _extractCode(String callbackUrl) {
-    if (callbackUrl.isEmpty) return '';
-    final uri = Uri.tryParse(callbackUrl);
-    if (uri == null) return '';
-    return uri.queryParameters['code'] ?? '';
-  }
-
   /// Refresh an existing access token using [refreshToken]. Returns the new
   /// token bundle (the refresh token may be rotated by Casdoor). Throws on
   /// failure so the caller can fall back to prompting for re-login.
@@ -204,4 +194,15 @@ class UniAuthService extends ChangeNotifier {
       expiresAt: data['expires_at'] as String?,
     );
   }
+}
+
+/// Pull the authorization code out of the full callback URL returned by the
+/// Casdoor SDK. Kept as a small pure function so the URL contract stays covered
+/// without opening a real login WebView in tests.
+@visibleForTesting
+String extractUniAuthCallbackCode(String callbackUrl) {
+  if (callbackUrl.isEmpty) return '';
+  final uri = Uri.tryParse(callbackUrl);
+  if (uri == null) return '';
+  return uri.queryParameters['code'] ?? '';
 }

--- a/test/login_page_test.dart
+++ b/test/login_page_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:techpie/pages/login_page.dart';
+import 'package:techpie/services/assignment_service.dart';
+import 'package:techpie/services/auth_service.dart';
+import 'package:techpie/services/debug_logger.dart';
+import 'package:techpie/services/http_client.dart';
+import 'package:techpie/services/oa_gym_service.dart';
+import 'package:techpie/services/schedule_service.dart';
+import 'package:techpie/services/service_provider.dart';
+import 'package:techpie/services/storage_service.dart';
+import 'package:techpie/services/sync_service.dart';
+import 'package:techpie/services/theme_service.dart';
+import 'package:techpie/services/third_party_auth_service.dart';
+import 'package:techpie/services/uni_auth_service.dart';
+
+void main() {
+  testWidgets('login failure keeps the login button reachable on a short screen', (
+    WidgetTester tester,
+  ) async {
+    tester.view.physicalSize = const Size(360, 480);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final storage = StorageService(prefs);
+    final logger = DebugLogger();
+    final http = LoggingHttpClient(logger);
+    final uniAuth = _FailingUniAuthService();
+    final auth = AuthService(storage, http, uniAuth);
+    final thirdPartyAuth = ThirdPartyAuthService(storage, http);
+    final schedule = ScheduleService(storage, http, auth, thirdPartyAuth);
+    final assignments =
+        AssignmentService(storage, http, auth, thirdPartyAuth, schedule);
+
+    await tester.pumpWidget(
+      ServiceProvider(
+        authService: auth,
+        debugLogger: logger,
+        storageService: storage,
+        themeService: ThemeService(storage),
+        scheduleService: schedule,
+        assignmentService: assignments,
+        thirdPartyAuthService: thirdPartyAuth,
+        oaGymService: OaGymService(auth, storage, thirdPartyAuth),
+        uniAuthService: uniAuth,
+        syncService: SyncService(auth, thirdPartyAuth, storage),
+        child: const MaterialApp(home: LoginPage()),
+      ),
+    );
+
+    final loginButton = find.widgetWithText(
+      FilledButton,
+      '通过 GeekPie Uni-Auth 登录',
+    );
+    await tester.ensureVisible(loginButton);
+    await tester.pumpAndSettle();
+    await tester.tap(loginButton);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('登录失败：'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+
+    await tester.ensureVisible(loginButton);
+    await tester.pumpAndSettle();
+    final buttonRect = tester.getRect(loginButton);
+    expect(buttonRect.top, greaterThanOrEqualTo(0));
+    expect(buttonRect.bottom, lessThanOrEqualTo(480));
+  });
+}
+
+class _FailingUniAuthService extends UniAuthService {
+  @override
+  Future<SsoTokens> login(BuildContext context) {
+    throw Exception(
+      '模拟一段足够长的认证错误，确保错误文本换行后不会盖住登录按钮。',
+    );
+  }
+}

--- a/test/login_page_test.dart
+++ b/test/login_page_test.dart
@@ -52,9 +52,10 @@ void main() {
       ),
     );
 
-    final loginButton = find.widgetWithText(
-      FilledButton,
-      '通过 GeekPie Uni-Auth 登录',
+    // Older Flutter versions use a private subclass for FilledButton.icon.
+    final loginButton = find.ancestor(
+      of: find.text('通过 GeekPie Uni-Auth 登录'),
+      matching: find.byWidgetPredicate((widget) => widget is FilledButton),
     );
     await tester.ensureVisible(loginButton);
     await tester.pumpAndSettle();

--- a/test/uni_auth_service_test.dart
+++ b/test/uni_auth_service_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:techpie/services/uni_auth_service.dart';
+
+void main() {
+  group('extractUniAuthCallbackCode', () {
+    test('extracts the code from the full custom-scheme callback URL', () {
+      expect(
+        extractUniAuthCallbackCode(
+          'techpie://auth-callback?code=authorization-code&state=state-token',
+        ),
+        'authorization-code',
+      );
+    });
+
+    test('decodes an encoded authorization code', () {
+      expect(
+        extractUniAuthCallbackCode(
+          'techpie://auth-callback?code=a%2Fb%2Bc%3D&state=state-token',
+        ),
+        'a/b+c=',
+      );
+    });
+
+    test('returns empty when the callback has no code', () {
+      expect(
+        extractUniAuthCallbackCode(
+          'techpie://auth-callback?error=access_denied',
+        ),
+        isEmpty,
+      );
+      expect(extractUniAuthCallbackCode(''), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
GeekPie Uni-Auth 登录失败时，在登录表单内显示错误，短屏上仍可滚动回到登录按钮。将已有回调 URL 的授权码提取逻辑移为可测试函数，并覆盖取消登录、编码字符和短屏错误提示。

独立于 #83，保留原有 GPG 签名提交 `d263163`。测试的按钮查找兼容 Flutter 3.27.4 中 `FilledButton.icon` 的私有子类，不依赖新版 Flutter 的内部实现。

验证：Flutter 3.27.4 静态检查、4 项登录相关测试以及修正后的完整 69 项测试通过。此分支不包含 ELRC 课程目录、媒体地址或对应提交历史。
