### PR TITLE
feat(elrc): add native course recordings

### DIFF
--- a/lib/models/feature.dart
+++ b/lib/models/feature.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../pages/elrc_recordings_page.dart';
 import '../pages/oa_gym_page.dart';
 import '../widgets/adaptive_page_navigation.dart';
 
@@ -35,6 +36,16 @@ class Feature {
 }
 
 final featureEntries = <Feature>[
+  Feature(
+    id: 'elrc_recordings',
+    description: '课程录播',
+    mode: FeatureMode.native,
+    nativeEntry: (context) => pushAdaptivePage<void>(
+      context,
+      builder: (_) => const ElrcRecordingsPage(),
+    ),
+    icon: const Icon(Icons.video_library_outlined),
+  ),
   Feature(
     id: 'ecourse',
     description: 'E云课堂',

--- a/lib/pages/elrc_player_page.dart
+++ b/lib/pages/elrc_player_page.dart
@@ -1,0 +1,362 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../services/elrc_client.dart';
+
+class ElrcPlayerPage extends StatefulWidget {
+  const ElrcPlayerPage({
+    super.key,
+    required this.courseName,
+    required this.lessonTitle,
+    required this.referer,
+    required this.sources,
+  });
+
+  final String courseName;
+  final String lessonTitle;
+  final Uri referer;
+  final List<ElrcSource> sources;
+
+  @override
+  State<ElrcPlayerPage> createState() => _ElrcPlayerPageState();
+}
+
+class _ElrcPlayerPageState extends State<ElrcPlayerPage> {
+  late final WebViewController _controller;
+  var _selected = 0;
+  var _loading = true;
+  var _closing = false;
+  var _loadGeneration = 0;
+  var _readyGeneration = 0;
+  var _hasPlaybackState = false;
+  Timer? _loadTimeout;
+  double _resumeSeconds = 0;
+  bool _resumePlaying = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController();
+    unawaited(_prepare());
+  }
+
+  Future<void> _prepare() async {
+    await _controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+    await _controller.addJavaScriptChannel(
+      'TechPiePlayer',
+      onMessageReceived: _playerMessage,
+    );
+    await _controller.setNavigationDelegate(
+      NavigationDelegate(
+        onNavigationRequest: (request) {
+          final uri = Uri.tryParse(request.url);
+          if (request.url == 'about:blank' ||
+              (uri?.scheme == 'https' && uri?.host == 'elrc.shanghaitech.edu.cn')) {
+            return NavigationDecision.navigate;
+          }
+          return NavigationDecision.prevent;
+        },
+        onPageFinished: _mediaDocumentReady,
+        onWebResourceError: _webResourceFailed,
+      ),
+    );
+    await _load(0, preservePlayback: false);
+  }
+
+  Future<void> _load(int index, {bool preservePlayback = true}) async {
+    if (!mounted || _closing || index < 0 || index >= widget.sources.length) return;
+    if (preservePlayback) await _rememberPlayback();
+    if (!mounted || _closing) return;
+    final generation = ++_loadGeneration;
+    _loadTimeout?.cancel();
+    _loadTimeout = Timer(
+      const Duration(seconds: 30),
+      () => _loadTimedOut(generation),
+    );
+    setState(() {
+      _selected = index;
+      _loading = true;
+      _error = null;
+    });
+    try {
+      await _controller.loadRequest(
+        widget.sources[index].uri,
+        headers: {'Referer': widget.referer.toString()},
+      );
+    } catch (_) {
+      if (_isCurrent(generation)) {
+        _loadTimeout?.cancel();
+        _trace('request failed before WebKit accepted it');
+        setState(() {
+          _loading = false;
+          _error = '视频加载失败';
+        });
+      }
+    }
+  }
+
+  Future<void> _rememberPlayback() async {
+    try {
+      final result = await _controller.runJavaScriptReturningResult('''
+JSON.stringify((() => {
+  const video = document.querySelector('video');
+  if (!video) return {};
+  return {
+    seconds: Number.isFinite(video.currentTime) ? video.currentTime : 0,
+    playing: !video.paused && !video.ended,
+  };
+})())
+''');
+      final decoded = jsonDecode(result.toString());
+      if (decoded is! Map<String, dynamic>) return;
+      final seconds = decoded['seconds'];
+      final playing = decoded['playing'];
+      if (seconds is num && seconds.isFinite && seconds >= 0) {
+        _resumeSeconds = seconds.toDouble();
+        _hasPlaybackState = true;
+      }
+      if (playing is bool) {
+        _resumePlaying = playing;
+        _hasPlaybackState = true;
+      }
+      _trace(
+        'remembered position=${_resumeSeconds.toStringAsFixed(1)}s '
+        'playing=$_resumePlaying',
+      );
+    } catch (_) {
+      _trace('playback state was not readable');
+    }
+  }
+
+  void _mediaDocumentReady(String url) {
+    if (!_matchesCurrentMedia(url)) {
+      _trace('ignored retired media document');
+      return;
+    }
+    _mediaReady(_loadGeneration, 'media document ready');
+  }
+
+  void _mediaReady(int generation, String reason) {
+    if (!_isCurrent(generation) || _readyGeneration == generation) return;
+    _readyGeneration = generation;
+    _trace(reason);
+    _showPlayer(generation);
+    unawaited(_restorePlayback(generation));
+  }
+
+  void _webResourceFailed(WebResourceError failure) {
+    _trace(
+      'resource callback main=${failure.isForMainFrame} '
+      'code=${failure.errorCode} type=${failure.errorType?.name}',
+    );
+    if (failure.isForMainFrame != true || _closing || !mounted) return;
+    if (!_matchesCurrentMedia(failure.url)) {
+      _trace('ignored callback from retired media');
+      return;
+    }
+
+    // WKWebView reports direct video documents as WebKit error 204 when AVKit
+    // takes over playback. The video is usable; this callback is its success path.
+    if (defaultTargetPlatform == TargetPlatform.iOS && failure.errorCode == 204) {
+      _mediaReady(_loadGeneration, 'native player accepted the media document');
+      return;
+    }
+
+    // Replacing a media document can cancel the retired navigation.
+    if (failure.errorCode == -999 ||
+        (defaultTargetPlatform == TargetPlatform.iOS && failure.errorCode == 102)) {
+      _trace('ignored retired media navigation');
+      return;
+    }
+
+    _loadTimeout?.cancel();
+    setState(() {
+      _loading = false;
+      _error = '视频加载失败';
+    });
+  }
+
+  bool _matchesCurrentMedia(String? url) =>
+      url == null || url == widget.sources[_selected].uri.toString();
+
+  void _loadTimedOut(int generation) {
+    if (!_isCurrent(generation) || _readyGeneration == generation) return;
+    _trace('load timed out after 30 seconds');
+    setState(() {
+      _loading = false;
+      _error = '视频加载超时';
+    });
+  }
+
+  void _showPlayer(int generation) {
+    if (!_isCurrent(generation)) return;
+    _loadTimeout?.cancel();
+    setState(() {
+      _loading = false;
+      _error = null;
+    });
+  }
+
+  Future<void> _restorePlayback(int generation) async {
+    if (!_isCurrent(generation) || !_hasPlaybackState) return;
+    final seconds = _resumeSeconds;
+    final resumePlaying = _resumePlaying;
+    try {
+      await _controller.runJavaScript('''
+(() => {
+  let attempts = 0;
+  const restore = () => {
+    const video = document.querySelector('video');
+    if (!video || video.readyState < 1) return false;
+    const duration = Number.isFinite(video.duration) ? video.duration : $seconds;
+    video.currentTime = Math.min($seconds, Math.max(0, duration - 0.25));
+    if ($resumePlaying) {
+      const play = video.play();
+      if (play) play.catch(() => {});
+    } else {
+      video.pause();
+    }
+    if (window.TechPiePlayer) {
+      window.TechPiePlayer.postMessage(JSON.stringify({
+        generation: $generation,
+        type: 'restored',
+        seconds: video.currentTime,
+      }));
+    }
+    return true;
+  };
+  if (restore()) return;
+  const timer = setInterval(() => {
+    attempts += 1;
+    if (restore() || attempts >= 40) clearInterval(timer);
+  }, 100);
+})();
+''');
+    } catch (_) {
+      _trace('playback restore was not available');
+    }
+  }
+
+  void _playerMessage(JavaScriptMessage message) {
+    if (_closing || message.message.length > 1024) return;
+    try {
+      final decoded = jsonDecode(message.message);
+      if (decoded is! Map<String, dynamic> || decoded['generation'] != _loadGeneration) return;
+      if (decoded['type'] == 'restored' && decoded['seconds'] is num) {
+        _trace('restored position=${(decoded['seconds'] as num).toStringAsFixed(1)}s');
+      }
+    } on FormatException {
+      return;
+    }
+  }
+
+  bool _isCurrent(int generation) => mounted && !_closing && generation == _loadGeneration;
+
+  void _trace(String message) {
+    if (kDebugMode) debugPrint('[ELRC player] $message');
+  }
+
+  void _close() {
+    if (_closing) return;
+    _closing = true;
+    _loadGeneration++;
+    _loadTimeout?.cancel();
+    Navigator.of(context).pop();
+  }
+
+  @override
+  void dispose() {
+    _closing = true;
+    _loadGeneration++;
+    _loadTimeout?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(
+          leading: BackButton(onPressed: _close),
+          title: Text(widget.courseName),
+        ),
+        body: SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                child: Text(
+                  widget.lessonTitle,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ),
+              if (widget.sources.length > 1)
+                SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+                  child: Row(
+                    children: [
+                      for (var index = 0; index < widget.sources.length; index++) ...[
+                        if (index > 0) const SizedBox(width: 8),
+                        ChoiceChip(
+                          label: Text(widget.sources[index].label),
+                          selected: index == _selected,
+                          onSelected: _loading ? null : (_) => unawaited(_load(index)),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              Expanded(
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    ColoredBox(
+                      color: Colors.black,
+                      child: WebViewWidget(controller: _controller),
+                    ),
+                    if (_loading)
+                      ColoredBox(
+                        color: Theme.of(context).colorScheme.surface,
+                        child: const Center(
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              CircularProgressIndicator(),
+                              SizedBox(height: 16),
+                              Text('正在加载视频'),
+                            ],
+                          ),
+                        ),
+                      ),
+                    if (_error != null)
+                      ColoredBox(
+                        color: Theme.of(context).colorScheme.surface,
+                        child: Center(
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const Icon(Icons.error_outline, size: 40),
+                              const SizedBox(height: 12),
+                              Text(_error!),
+                              const SizedBox(height: 16),
+                              FilledButton(
+                                onPressed: () => unawaited(_load(_selected)),
+                                child: const Text('重新加载'),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+}

--- a/lib/pages/elrc_recordings_page.dart
+++ b/lib/pages/elrc_recordings_page.dart
@@ -1,0 +1,613 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../services/elrc_client.dart';
+import '../widgets/adaptive_page_navigation.dart';
+import 'elrc_player_page.dart';
+
+class ElrcRecordingsPage extends StatefulWidget {
+  const ElrcRecordingsPage({super.key});
+
+  @override
+  State<ElrcRecordingsPage> createState() => _ElrcRecordingsPageState();
+}
+
+class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
+  static final _reviewUri = Uri.parse(
+    'https://elrc.shanghaitech.edu.cn/learn/videoreview?type=1',
+  );
+  static final _loginUri = Uri.https(
+    'elrc.shanghaitech.edu.cn',
+    '/unifiedlogin/v1/loginmanage/login/direction',
+    {'redirect_url': _reviewUri.toString()},
+  );
+
+  WebViewController? _controller;
+  ElrcClient? _client;
+  List<ElrcCourse>? _courses;
+  ElrcCourse? _selectedCourse;
+  List<ElrcLesson>? _lessons;
+  String? _error;
+  Uri? _activeUri;
+  int _request = 0;
+  bool _starting = true;
+  bool _busy = false;
+  bool _webVisible = false;
+  bool _reviewFinished = false;
+  bool _sessionReloadRequired = false;
+  bool _loginPresented = false;
+  var _expectedMainFrameCancellations = 0;
+
+  bool get _supported =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.iOS ||
+          defaultTargetPlatform == TargetPlatform.android);
+
+  @override
+  void initState() {
+    super.initState();
+    if (_supported) unawaited(_prepare());
+  }
+
+  Future<void> _prepare() async {
+    final controller = WebViewController();
+    final client = ElrcClient(controller);
+    try {
+      await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+      await client.initialize();
+      await controller.setNavigationDelegate(
+        NavigationDelegate(
+          onNavigationRequest: (request) {
+            final uri = Uri.tryParse(request.url);
+            _trace('navigation request ${_safeUri(uri)}');
+            if (request.url == 'about:blank') {
+              return NavigationDecision.navigate;
+            }
+            if (_isHttpElrc(uri)) {
+              final target = uri!.replace(scheme: 'https', port: 443);
+              _expectedMainFrameCancellations++;
+              _trace('upgrade navigation to ${_safeUri(target)}');
+              unawaited(
+                controller.loadRequest(target),
+              );
+              return NavigationDecision.prevent;
+            }
+            if (_isHttpsElrc(uri) || _isLogin(uri)) {
+              return NavigationDecision.navigate;
+            }
+            return NavigationDecision.prevent;
+          },
+          onPageStarted: (url) {
+            _trace('page started ${_safeUri(Uri.tryParse(url))}');
+            _activate(url, pageStarted: true);
+          },
+          onUrlChange: (change) {
+            _trace('URL changed ${_safeUri(Uri.tryParse(change.url ?? ''))}');
+            _activate(change.url);
+          },
+          onPageFinished: (url) {
+            _trace('page finished ${_safeUri(Uri.tryParse(url))}');
+            _navigationFinished(url);
+          },
+          onWebResourceError: _webResourceFailed,
+        ),
+      );
+      if (!mounted) {
+        client.dispose();
+        return;
+      }
+      _controller = controller;
+      _client = client;
+      setState(() {});
+      await controller.loadRequest(_reviewUri);
+    } catch (_) {
+      client.dispose();
+      if (!mounted) return;
+      if (identical(_client, client)) {
+        _client = null;
+        _controller = null;
+      }
+      setState(() {
+        _starting = false;
+        _busy = false;
+        _webVisible = false;
+        _sessionReloadRequired = true;
+        _error = 'ELRC 页面加载失败';
+      });
+    }
+  }
+
+  bool _isHttpElrc(Uri? uri) =>
+      uri?.scheme == 'http' &&
+      uri?.host == 'elrc.shanghaitech.edu.cn' &&
+      uri?.port == 80 &&
+      uri?.userInfo.isEmpty == true;
+
+  bool _isHttpsElrc(Uri? uri) =>
+      uri?.scheme == 'https' &&
+      uri?.host == 'elrc.shanghaitech.edu.cn' &&
+      uri?.port == 443 &&
+      uri?.userInfo.isEmpty == true;
+
+  bool _isReview(Uri? uri) =>
+      _isHttpsElrc(uri) &&
+      (uri?.path == '/learn/videoreview' || uri?.path == '/learn/videoreview/');
+
+  bool _isAppSide(Uri? uri) =>
+      _isHttpsElrc(uri) && (uri?.path == '/appside' || uri?.path == '/appside/');
+
+  bool _isSessionPage(Uri? uri) => _isReview(uri) || _isAppSide(uri);
+
+  bool _isLogin(Uri? uri) =>
+      uri?.scheme == 'https' &&
+      uri?.host == 'ids.shanghaitech.edu.cn' &&
+      uri?.port == 443 &&
+      uri?.userInfo.isEmpty == true;
+
+  void _trace(String message) {
+    if (kDebugMode) debugPrint('[ELRC] $message');
+  }
+
+  String _safeUri(Uri? uri) {
+    if (uri == null) return '<invalid URL>';
+    final port = uri.hasPort ? ':${uri.port}' : '';
+    return '${uri.scheme}://${uri.host}$port${uri.path}';
+  }
+
+  void _activate(String? url, {bool pageStarted = false}) {
+    final uri = Uri.tryParse(url ?? '');
+    if (uri == null) return;
+    final wasSessionPage = _isSessionPage(_activeUri);
+    _activeUri = uri;
+    if (_isSessionPage(uri) && (pageStarted || !wasSessionPage)) {
+      _reviewFinished = false;
+    }
+    if (!mounted) return;
+
+    final login = _isLogin(uri);
+    setState(() {
+      _webVisible = login;
+      if (login) {
+        _loginPresented = true;
+        _starting = false;
+        _busy = false;
+      } else if (_isHttpsElrc(uri)) {
+        _starting = _courses == null;
+        if (_isSessionPage(uri)) {
+          _error = null;
+          _sessionReloadRequired = false;
+        }
+      }
+    });
+  }
+
+  void _navigationFinished(String url) {
+    final uri = Uri.tryParse(url);
+    if (_isSessionPage(uri) && _isSessionPage(_activeUri)) {
+      if (_reviewFinished) return;
+      _reviewFinished = true;
+      if (mounted) {
+        setState(() => _webVisible = false);
+        unawaited(_loadCourses());
+      }
+      return;
+    }
+    if (_isLogin(uri) && _isLogin(_activeUri) && mounted) {
+      setState(() {
+        _starting = false;
+        _webVisible = true;
+      });
+    }
+  }
+
+  void _webResourceFailed(WebResourceError error) {
+    _trace(
+      'resource error main=${error.isForMainFrame} '
+      'code=${error.errorCode} type=${error.errorType?.name} '
+      '${_safeUri(Uri.tryParse(error.url ?? ''))}',
+    );
+    if (error.isForMainFrame != true) return;
+    if (error.errorCode == 102 && _expectedMainFrameCancellations > 0) {
+      _expectedMainFrameCancellations--;
+      _trace('ignored expected replacement-navigation cancellation');
+      return;
+    }
+    _pageLoadFailed();
+  }
+
+  void _pageLoadFailed() {
+    if (!mounted) return;
+    setState(() {
+      _starting = false;
+      _busy = false;
+      _sessionReloadRequired = true;
+      _error = 'ELRC 页面加载失败';
+      if (!_isLogin(_activeUri)) _webVisible = false;
+    });
+  }
+
+  Future<void> _reloadReview() async {
+    final controller = _controller;
+    if (controller == null) {
+      await _prepare();
+      return;
+    }
+    final request = ++_request;
+    _reviewFinished = false;
+    setState(() {
+      _courses = null;
+      _selectedCourse = null;
+      _lessons = null;
+      _error = null;
+      _starting = true;
+      _busy = false;
+      _webVisible = false;
+      _sessionReloadRequired = false;
+    });
+    try {
+      await controller.loadRequest(_reviewUri);
+    } catch (_) {
+      if (!mounted || request != _request) return;
+      setState(() {
+        _starting = false;
+        _sessionReloadRequired = true;
+        _error = 'ELRC 页面加载失败';
+      });
+    }
+  }
+
+  Future<void> _openLogin() async {
+    final controller = _controller;
+    if (controller == null) {
+      await _prepare();
+      return;
+    }
+    _reviewFinished = false;
+    setState(() {
+      _loginPresented = true;
+      _error = null;
+      _starting = true;
+      _busy = false;
+      _webVisible = false;
+      _sessionReloadRequired = true;
+    });
+    _trace('opening fixed ELRC login entry');
+    try {
+      await controller.loadRequest(_loginUri);
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _starting = false;
+        _error = 'ELRC 登录页面加载失败';
+      });
+    }
+  }
+
+  Future<void> _loadCourses() async {
+    final client = _client;
+    if (client == null || _busy || !_isSessionPage(_activeUri)) return;
+    final request = ++_request;
+    _trace('course request started from ${_safeUri(_activeUri)}');
+    setState(() {
+      _busy = true;
+      _starting = false;
+      _error = null;
+      _sessionReloadRequired = false;
+    });
+    try {
+      final courses = await client.courses();
+      if (!mounted || request != _request) return;
+      _trace('course request completed with ${courses.length} courses');
+      if (courses.isEmpty && !_loginPresented) {
+        _trace('empty initial course list; opening login');
+        await _openLogin();
+        return;
+      }
+      setState(() {
+        _courses = courses;
+        _selectedCourse = null;
+        _lessons = null;
+      });
+    } on ElrcException catch (error) {
+      if (!mounted || request != _request) return;
+      _trace('course request failed: ${error.message}');
+      if (error.needsLogin) {
+        await _openLogin();
+        return;
+      }
+      setState(() {
+        _error = error.message;
+        _sessionReloadRequired = error.needsLogin;
+      });
+    } catch (_) {
+      if (!mounted || request != _request) return;
+      setState(() => _error = '课程列表加载失败');
+    } finally {
+      if (mounted && request == _request) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _loadLessons(ElrcCourse course) async {
+    final client = _client;
+    if (client == null || _busy || !_isSessionPage(_activeUri)) return;
+    final request = ++_request;
+    setState(() {
+      _selectedCourse = course;
+      _lessons = null;
+      _error = null;
+      _busy = true;
+      _sessionReloadRequired = false;
+    });
+    try {
+      final lessons = await client.lessons(course);
+      if (!mounted || request != _request) return;
+      setState(() => _lessons = lessons);
+    } on ElrcException catch (error) {
+      if (!mounted || request != _request) return;
+      setState(() {
+        _error = error.message;
+        _sessionReloadRequired = error.needsLogin;
+      });
+    } catch (_) {
+      if (!mounted || request != _request) return;
+      setState(() => _error = '录播课次加载失败');
+    } finally {
+      if (mounted && request == _request) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _openLesson(ElrcLesson lesson) async {
+    final course = _selectedCourse;
+    final client = _client;
+    if (course == null || client == null || _busy) return;
+    final request = ++_request;
+    setState(() {
+      _busy = true;
+      _error = null;
+      _sessionReloadRequired = false;
+    });
+    try {
+      final sources = await client.sources(course, lesson);
+      if (!mounted || request != _request) return;
+      setState(() => _busy = false);
+      await pushAdaptivePage<void>(
+        context,
+        builder: (_) => ElrcPlayerPage(
+          courseName: course.name,
+          lessonTitle: lesson.title,
+          referer: course.referer,
+          sources: sources,
+        ),
+      );
+    } on ElrcException catch (error) {
+      if (!mounted || request != _request) return;
+      setState(() {
+        _error = error.message;
+        _sessionReloadRequired = error.needsLogin;
+      });
+    } catch (_) {
+      if (!mounted || request != _request) return;
+      setState(() => _error = '播放地址加载失败');
+    } finally {
+      if (mounted && request == _request) setState(() => _busy = false);
+    }
+  }
+
+  void _showCourses() {
+    if (_busy) return;
+    setState(() {
+      _selectedCourse = null;
+      _lessons = null;
+      _error = null;
+      _sessionReloadRequired = false;
+    });
+  }
+
+  void _retryCourses() {
+    unawaited(
+      _sessionReloadRequired
+          ? _openLogin()
+          : _courses == null
+              ? _reloadReview()
+              : _loadCourses(),
+    );
+  }
+
+  void _retryLessons(ElrcCourse course) {
+    unawaited(
+      _sessionReloadRequired ? _openLogin() : _loadLessons(course),
+    );
+  }
+
+  Widget _message(String text, VoidCallback retry) => Center(
+        child: Padding(
+          padding: const EdgeInsets.all(28),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.info_outline, size: 42),
+              const SizedBox(height: 12),
+              Text(text, textAlign: TextAlign.center),
+              const SizedBox(height: 16),
+              FilledButton(
+                onPressed: _busy ? null : retry,
+                child: const Text('重新加载'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+  Widget _errorCard(VoidCallback retry) => Card.filled(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  _error!,
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
+              ),
+              TextButton(
+                onPressed: _busy ? null : retry,
+                child: const Text('重试'),
+              ),
+            ],
+          ),
+        ),
+      );
+
+  Widget _content() {
+    if (!_supported) {
+      return const Center(child: Text('请在 iPhone 或 Android 手机中观看录播'));
+    }
+    if (_error != null && _courses == null && !_webVisible) {
+      return _message(_error!, _retryCourses);
+    }
+    if ((_starting || _busy) && _courses == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final selectedCourse = _selectedCourse;
+    if (selectedCourse != null) {
+      final lessons = _lessons;
+      if (_busy && lessons == null) {
+        return const Center(child: CircularProgressIndicator());
+      }
+      if (lessons == null) {
+        return _message(
+          _error ?? '录播课次加载失败',
+          () => _retryLessons(selectedCourse),
+        );
+      }
+      return ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          if (selectedCourse.description.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Text(selectedCourse.description),
+            ),
+          if (_error != null)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: _errorCard(() => _retryLessons(selectedCourse)),
+            ),
+          for (final lesson in lessons)
+            Card.outlined(
+              child: ListTile(
+                title: Text(lesson.title),
+                subtitle: lesson.weekDate.isEmpty ? null : Text(lesson.weekDate),
+                trailing: const Icon(Icons.play_circle_outline),
+                onTap: _busy ? null : () => unawaited(_openLesson(lesson)),
+              ),
+            ),
+        ],
+      );
+    }
+
+    final courses = _courses;
+    if (courses == null) {
+      return _message(_error ?? '课程列表加载失败', _retryCourses);
+    }
+    if (courses.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('当前账号暂无课程录播'),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: _openLogin,
+              child: const Text('重新登录'),
+            ),
+          ],
+        ),
+      );
+    }
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        if (_error != null)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: _errorCard(_retryCourses),
+          ),
+        for (final course in courses)
+          Card.outlined(
+            child: ListTile(
+              leading: const Icon(Icons.video_library_outlined),
+              title: Text(course.name),
+              subtitle: course.description.isEmpty ? null : Text(course.description),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: _busy ? null : () => unawaited(_loadLessons(course)),
+            ),
+          ),
+      ],
+    );
+  }
+
+  @override
+  void dispose() {
+    _request++;
+    _client?.dispose();
+    _client = null;
+    _controller = null;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => PopScope(
+        canPop: _selectedCourse == null,
+        onPopInvokedWithResult: (didPop, _) {
+          if (!didPop) _showCourses();
+        },
+        child: Scaffold(
+          appBar: AppBar(
+            automaticallyImplyLeading: _selectedCourse == null,
+            leading: _selectedCourse == null
+                ? null
+                : IconButton(
+                    onPressed: _busy ? null : _showCourses,
+                    icon: const Icon(Icons.arrow_back),
+                  ),
+            title: Text(_webVisible ? '登录课程录播' : '课程录播'),
+            actions: [
+              if (!_webVisible && !_starting)
+                IconButton(
+                  tooltip: '刷新',
+                  onPressed: _busy
+                      ? null
+                      : _selectedCourse == null
+                          ? _retryCourses
+                          : () => _retryLessons(_selectedCourse!),
+                  icon: const Icon(Icons.refresh),
+                ),
+            ],
+          ),
+          body: SafeArea(
+            child: Stack(
+              children: [
+                Positioned.fill(child: _content()),
+                if (_controller != null)
+                  Positioned.fill(
+                    child: Offstage(
+                      offstage: !_webVisible,
+                      child: WebViewWidget(controller: _controller!),
+                    ),
+                  ),
+                if (_busy && (_courses != null || _lessons != null) && !_webVisible)
+                  const Align(
+                    alignment: Alignment.topCenter,
+                    child: LinearProgressIndicator(),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      );
+}

--- a/lib/services/elrc_client.dart
+++ b/lib/services/elrc_client.dart
@@ -1,0 +1,575 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:webview_flutter/webview_flutter.dart';
+
+const _origin = 'https://elrc.shanghaitech.edu.cn';
+const _courseList = '/learn/v1/course/video/review/1';
+const _courseInfo = '/learn/v1/course/recording/video/info';
+const _videoInfo = '/rman/v1/search/new/relation/videos';
+const _fileInfo = '/rman/v1/entity/download/fileinfo';
+
+class ElrcCourse {
+  const ElrcCourse(
+    this.name,
+    this.courseId, {
+    this.reviewId,
+    this.courseNo,
+    this.schoolYear,
+    this.semester,
+    this.description = '',
+  });
+
+  final String name;
+  final String courseId;
+  final String? reviewId;
+  final String? courseNo;
+  final String? schoolYear;
+  final String? semester;
+  final String description;
+
+  Uri get referer => Uri.https(
+        'elrc.shanghaitech.edu.cn',
+        '/learn/videoreview/$courseId',
+        {
+          if (reviewId != null) 'id': reviewId!,
+          if (schoolYear != null) 'schoolYear': schoolYear!,
+          if (semester != null) 'semester': semester!,
+        },
+      );
+}
+
+class ElrcLesson {
+  ElrcLesson({
+    required this.courseId,
+    required this.courseNo,
+    required this.week,
+    required this.weekDay,
+    required this.weekDate,
+    required this.section,
+    required List<String> scheduleIds,
+  }) : scheduleIds = List.unmodifiable(scheduleIds);
+
+  final String courseId;
+  final String courseNo;
+  final String week;
+  final String weekDay;
+  final String weekDate;
+  final String section;
+  final List<String> scheduleIds;
+
+  String get title => '第$week周 $weekDay · $section节';
+
+  Map<String, Object> get query => {
+        'courseId': courseId,
+        'courseNo': courseNo,
+        'week': week,
+        'weekDay': weekDay,
+        'section': section,
+        'scheduleIds': scheduleIds,
+      };
+}
+
+class ElrcSource {
+  const ElrcSource(this.label, this.uri);
+
+  final String label;
+  final Uri uri;
+}
+
+class ElrcException implements Exception {
+  const ElrcException(this.message, {this.needsLogin = false});
+
+  final String message;
+  final bool needsLogin;
+
+  @override
+  String toString() => message;
+}
+
+enum _EnvelopeKind { status, success }
+
+class ElrcClient {
+  ElrcClient(this.webView);
+
+  final WebViewController webView;
+  Completer<_Response>? _pending;
+  var _requestId = 0;
+  var _disposed = false;
+
+  Future<void> initialize() => webView.addJavaScriptChannel(
+        'TechPieElrc',
+        onMessageReceived: (message) {
+          if (_disposed || message.message.length > 5 * 1024 * 1024) return;
+          try {
+            final Object? value = jsonDecode(message.message);
+            final pending = _pending;
+            if (value is! Map<String, dynamic> ||
+                value['id'] != _requestId ||
+                value['status'] is! num ||
+                value['body'] is! String ||
+                pending == null ||
+                pending.isCompleted) {
+              return;
+            }
+            pending.complete(
+              _Response(
+                (value['status'] as num).toInt(),
+                value['body'] as String,
+              ),
+            );
+          } on FormatException {
+            return;
+          }
+        },
+      );
+
+  Future<List<ElrcCourse>> courses() async {
+    final result = <String, ElrcCourse>{};
+    for (var page = 1; page <= 400; page++) {
+      final data = _object(
+        await _request(
+          _courseList,
+          kind: _EnvelopeKind.status,
+          query: {
+            'type': '1',
+            'page': '$page',
+            'size': '50',
+            'courseTime': '1',
+            'playType': '0',
+            'orderBy': 'course_name',
+          },
+        ),
+      );
+      final total = data['total'];
+      final size = data['size'];
+      if (data['page'] != page || total is! int || total < 0 || size is! int || size < 1) {
+        throw const ElrcException('课程列表格式发生变化');
+      }
+
+      final rows = _items(data['results']);
+      final previousCount = result.length;
+      for (final value in rows) {
+        final row = _object(value);
+        final name = _requiredText(row['courseName']);
+        final id = _requiredText(row['courseId']);
+        final number = _optional(row['courseNumber']);
+        final serial = _optional(row['serialNumber']);
+        final term = _optional(row['showSemester']);
+        final course = ElrcCourse(
+          name,
+          id,
+          reviewId: _optional(row['id']),
+          courseNo: number,
+          schoolYear: _optional(row['schoolYear']),
+          semester: _optional(row['semester']),
+          description: [number, serial, term]
+              .whereType<String>()
+              .where((part) => part.isNotEmpty)
+              .join(' · '),
+        );
+        result.putIfAbsent(course.referer.toString(), () => course);
+      }
+      if (page * size >= total) {
+        return List.unmodifiable(result.values);
+      }
+      if (rows.isEmpty || result.length == previousCount) {
+        throw const ElrcException('课程列表分页异常');
+      }
+    }
+    throw const ElrcException('课程列表分页异常');
+  }
+
+  Future<List<ElrcLesson>> lessons(ElrcCourse course) async {
+    final data = _object(
+      await _request(
+        _courseInfo,
+        kind: _EnvelopeKind.status,
+        referer: course.referer,
+        query: {
+          'courseId': course.courseId,
+          if (course.reviewId != null) 'id': course.reviewId!,
+          if (course.schoolYear != null) 'schoolYear': course.schoolYear!,
+          if (course.semester != null) 'semester': course.semester!,
+        },
+      ),
+    );
+    if (_requiredText(data['courseId']) != course.courseId) {
+      throw const ElrcException('返回的课程与所选课程不一致');
+    }
+    final result = <String, ElrcLesson>{};
+    for (final weekValue in _items(data['recordingVideoInfoShows'])) {
+      final week = _object(weekValue);
+      for (final detailValue in _items(week['recordInfoDetailList'])) {
+        final detail = _object(detailValue);
+        final live = detail['courseLiveInfo'] == null
+            ? <String, dynamic>{}
+            : _object(detail['courseLiveInfo']);
+        final nestedCourseId = _text(live['courseId']);
+        if (nestedCourseId.isNotEmpty && nestedCourseId != course.courseId) {
+          throw const ElrcException('课次与所选课程不一致');
+        }
+        final schedules = <String>{};
+        final liveSchedule = _text(live['scheduleId']);
+        if (liveSchedule.isNotEmpty) schedules.add(liveSchedule);
+        for (final value in _items(detail['videoInfoList'])) {
+          final scheduleId = _text(_object(value)['scheduleId']);
+          if (scheduleId.isNotEmpty) schedules.add(scheduleId);
+        }
+        final lesson = ElrcLesson(
+          courseId: nestedCourseId.isEmpty ? course.courseId : nestedCourseId,
+          courseNo: _first([
+            live['courseNo'],
+            detail['courseNo'],
+            detail['course_number'],
+            detail['courseNumber'],
+            data['courseNo'],
+            data['course_number'],
+            data['courseNumber'],
+            course.courseNo,
+          ]),
+          week: _text(week['week']),
+          weekDay: _text(detail['weekDay']),
+          weekDate: _text(detail['weekDate']),
+          section: _text(detail['section']),
+          scheduleIds: schedules.toList(),
+        );
+        if (lesson.courseNo.isEmpty ||
+            lesson.week.isEmpty ||
+            lesson.weekDay.isEmpty ||
+            lesson.section.isEmpty ||
+            lesson.scheduleIds.isEmpty) {
+          continue;
+        }
+        result[jsonEncode([
+          lesson.courseId,
+          lesson.courseNo,
+          lesson.week,
+          lesson.weekDay,
+          lesson.section,
+          lesson.scheduleIds,
+        ])] = lesson;
+      }
+    }
+    if (result.isEmpty) throw const ElrcException('这门课程暂无录播课次');
+    return List.unmodifiable(result.values);
+  }
+
+  Future<List<ElrcSource>> sources(
+    ElrcCourse course,
+    ElrcLesson lesson,
+  ) async {
+    if (lesson.courseId != course.courseId) {
+      throw const ElrcException('课次与所选课程不一致');
+    }
+
+    final videoPage = _object(
+      await _request(
+        _videoInfo,
+        kind: _EnvelopeKind.success,
+        body: lesson.query,
+        referer: course.referer,
+      ),
+    );
+    final videos = <String, Map<String, dynamic>>{};
+    for (final value in _items(videoPage['data'])) {
+      final video = _object(value);
+      final contentId = _requiredText(video['contentId_']);
+      if (videos.containsKey(contentId)) {
+        throw const ElrcException('视频标识重复');
+      }
+      videos[contentId] = video;
+    }
+    if (videos.isEmpty) throw const ElrcException('这个课次暂无视频');
+
+    final files = <String, Map<String, dynamic>>{};
+    for (final value in _items(
+      await _request(
+        _fileInfo,
+        kind: _EnvelopeKind.success,
+        body: videos.keys.toList(),
+        referer: course.referer,
+      ),
+    )) {
+      final file = _object(value);
+      final contentId = _requiredText(file['contentId']);
+      if (files.containsKey(contentId)) {
+        throw const ElrcException('视频文件标识重复');
+      }
+      files[contentId] = file;
+    }
+
+    final result = <ElrcSource>[];
+    var index = 0;
+    for (final entry in videos.entries) {
+      final video = entry.value;
+      final file = files[entry.key];
+      if (file == null) {
+        throw const ElrcException('视频信息与文件信息不一致');
+      }
+      final address = _address(file);
+      if (address == null) {
+        throw const ElrcException('没有可播放的视频地址');
+      }
+      final name = _first([
+        video['seat'],
+        file['seat'],
+        video['name'],
+        video['name_'],
+        file['entityName'],
+      ]);
+      result.add(
+        ElrcSource(
+          _sourceLabel(name, index),
+          _mediaUri(address),
+        ),
+      );
+      index++;
+    }
+    return List.unmodifiable(result);
+  }
+
+  String _sourceLabel(String name, int index) {
+    final normalized = name.toLowerCase();
+    if (normalized.contains('tchpan') || name.contains('全景')) {
+      return '全景画面';
+    }
+    if (normalized.contains('screen') || name.contains('屏幕')) {
+      return '屏幕画面';
+    }
+    if (normalized == 'tch' ||
+        normalized.contains('teacher') ||
+        name.contains('教师') ||
+        name.contains('近景')) {
+      return '教师画面';
+    }
+    return name.isEmpty ? '机位 ${index + 1}' : name;
+  }
+
+  Future<Object?> _request(
+    String path, {
+    required _EnvelopeKind kind,
+    Map<String, String>? query,
+    Object? body,
+    Uri? referer,
+  }) async {
+    final response = await _send(
+      Uri.https('elrc.shanghaitech.edu.cn', path, query),
+      body,
+      referer ?? Uri.parse('$_origin/learn/videoreview?type=1'),
+    );
+    final responseBody = response.body.replaceFirst('\uFEFF', '');
+    if (response.status == 401 || responseBody.trimLeft().startsWith('<')) {
+      throw const ElrcException('ELRC 登录已失效', needsLogin: true);
+    }
+    if (response.status == 403) throw const ElrcException('没有访问权限');
+    if (response.status == 0 ||
+        response.status == 408 ||
+        response.status == 429 ||
+        response.status >= 500) {
+      throw const ElrcException('ELRC 网络连接失败');
+    }
+    if (response.status < 200 || response.status >= 300) {
+      throw ElrcException('ELRC 请求失败（${response.status}）');
+    }
+    try {
+      final Object? decoded = jsonDecode(responseBody);
+      final envelope = _object(decoded);
+      return switch (kind) {
+        _EnvelopeKind.status => _readStatusData(envelope),
+        _EnvelopeKind.success => _readSuccessData(envelope),
+      };
+    } on FormatException {
+      throw const ElrcException('ELRC 返回格式发生变化');
+    }
+  }
+
+  Object? _readStatusData(Map<String, dynamic> envelope) {
+    final status = envelope['status'];
+    if (status != null && status is! num) {
+      throw const ElrcException('ELRC 返回格式发生变化');
+    }
+    if (status is num && status != 0 && status != 200) {
+      if (status == 401) {
+        throw const ElrcException('ELRC 登录已失效', needsLogin: true);
+      }
+      if (status == 403) throw const ElrcException('没有访问权限');
+      final message = _text(envelope['message']);
+      throw ElrcException(message.isEmpty ? 'ELRC 请求失败' : message);
+    }
+    if (!envelope.containsKey('data') || !_hasData(envelope['data'])) {
+      throw const ElrcException('ELRC 返回格式发生变化');
+    }
+    return envelope['data'];
+  }
+
+  Object? _readSuccessData(Map<String, dynamic> envelope) {
+    final success = envelope['success'];
+    if (success != null && success is! bool) {
+      throw const ElrcException('ELRC 返回格式发生变化');
+    }
+    if (success == false) throw const ElrcException('ELRC 请求失败');
+    if (!envelope.containsKey('data') || !_hasData(envelope['data'])) {
+      throw const ElrcException('ELRC 返回格式发生变化');
+    }
+    return envelope['data'];
+  }
+
+  Future<_Response> _send(Uri uri, Object? body, Uri referer) async {
+    if (_disposed) throw const ElrcException('ELRC 页面已关闭');
+    if (_pending != null) throw const ElrcException('上一个请求尚未完成');
+    final id = ++_requestId;
+    final pending = _pending = Completer<_Response>();
+    final encodedBody = body == null ? null : jsonEncode(body);
+    try {
+      await webView.runJavaScript('''
+(async () => {
+  const id = $id;
+  if (location.origin !== ${jsonEncode(_origin)}) {
+    TechPieElrc.postMessage(JSON.stringify({id, status: 0, body: ''}));
+    return;
+  }
+  try {
+    const response = await fetch(${jsonEncode(uri.toString())}, {
+      method: ${jsonEncode(body == null ? 'GET' : 'POST')},
+      credentials: 'same-origin',
+      redirect: 'error',
+      cache: 'no-store',
+      referrer: ${jsonEncode(referer.toString())},
+      headers: {
+        'Accept': '*/*',
+        'Accept-Language': 'zh-CN,zh;q=0.8,en-US;q=0.7',
+        ${encodedBody == null ? '' : "'Content-Type': 'application/json; charset=utf-8',"}
+      },
+      ${encodedBody == null ? '' : 'body: ${jsonEncode(encodedBody)},'}
+    });
+    const text = await response.text();
+    TechPieElrc.postMessage(JSON.stringify({
+      id,
+      status: response.status,
+      body: text.length <= 4 * 1024 * 1024 ? text : ''
+    }));
+  } catch (_) {
+    TechPieElrc.postMessage(JSON.stringify({id, status: 0, body: ''}));
+  }
+})();
+''');
+      return await pending.future.timeout(const Duration(seconds: 25));
+    } on TimeoutException {
+      throw const ElrcException('ELRC 请求超时');
+    } on ElrcException {
+      rethrow;
+    } catch (_) {
+      throw const ElrcException('ELRC 网络连接失败');
+    } finally {
+      if (identical(_pending, pending)) _pending = null;
+    }
+  }
+
+  void dispose() {
+    _disposed = true;
+    final pending = _pending;
+    if (pending != null && !pending.isCompleted) {
+      pending.completeError(const ElrcException('ELRC 页面已关闭'));
+    }
+    _pending = null;
+  }
+}
+
+class _Response {
+  const _Response(this.status, this.body);
+  final int status;
+  final String body;
+}
+
+Map<String, dynamic> _object(Object? value) {
+  if (value is Map<String, dynamic>) return value;
+  throw const ElrcException('ELRC 返回格式发生变化');
+}
+
+List<dynamic> _items(Object? value) {
+  if (value is List<dynamic>) return value;
+  throw const ElrcException('ELRC 返回格式发生变化');
+}
+
+bool _hasData(Object? value) {
+  if (value == null) return false;
+  if (value is List<Object?>) return value.isNotEmpty;
+  if (value is Map<Object?, Object?>) return value.isNotEmpty;
+  return true;
+}
+
+String _text(Object? value) {
+  if (value is String) return value.trim();
+  if (value is num) return value.toString();
+  return '';
+}
+
+String _requiredText(Object? value) {
+  final result = _text(value);
+  if (result.isEmpty) {
+    throw const ElrcException('ELRC 返回格式发生变化');
+  }
+  return result;
+}
+
+String? _optional(Object? value) {
+  if (value == null) return null;
+  final result = _text(value);
+  if (value is String && result.isEmpty) return null;
+  if (result.isEmpty) {
+    throw const ElrcException('ELRC 返回格式发生变化');
+  }
+  return result;
+}
+
+String _first(Iterable<Object?> values) {
+  for (final value in values) {
+    final result = _text(value);
+    if (result.isNotEmpty) return result;
+  }
+  return '';
+}
+
+String? _address(Map<String, dynamic> file) {
+  for (final group in _items(file['fileGroups'])) {
+    for (final value in _items(_object(group)['files'])) {
+      final address = _text(_object(value)['downloadAddress']);
+      if (address.isNotEmpty) return address;
+    }
+  }
+  for (final value in _items(file['downloadAddress'])) {
+    final address = _text(value);
+    if (address.isNotEmpty) return address;
+  }
+  return null;
+}
+
+Uri _mediaUri(String address) {
+  final normalized = address.trim();
+  if (normalized.isEmpty ||
+      normalized.codeUnits.any(
+        (value) => value <= 0x20 || value == 0x7f || value == 0x5c,
+      )) {
+    throw const ElrcException('视频地址格式不正确');
+  }
+  final Uri uri;
+  try {
+    uri = Uri.parse(_origin).resolve(normalized);
+  } on FormatException {
+    throw const ElrcException('视频地址格式不正确');
+  }
+  if (uri.scheme != 'https' ||
+      uri.host != 'elrc.shanghaitech.edu.cn' ||
+      uri.port != 443 ||
+      uri.userInfo.isNotEmpty ||
+      uri.hasFragment) {
+    throw const ElrcException('视频地址不属于 ELRC');
+  }
+  if (!uri.path.contains('/bucket-z/') || uri.queryParameters.containsKey('isSysAuth')) {
+    return uri;
+  }
+  return Uri.parse(
+    '${uri.toString()}${uri.query.isEmpty ? '?' : '&'}isSysAuth=true',
+  );
+}


### PR DESCRIPTION
## Summary
- add a native course-recording entry with course and lesson lists
- keep the official login WebView as the authenticated same-origin request channel
- preserve playback position and paused state while switching sources
- label teacher, panorama, and screen sources distinctly
- route a first empty course response directly to the school login page

This is a clean, four-file replacement for #83.

## Verification
- targeted Flutter analysis: no issues
- full repository analysis: only 6 pre-existing infos outside this change
- iPhone 17 Pro simulator: clean first-entry login, authenticated course loading, playback, source switching, and closing the native player without a false error