### PR TITLE
fix(ci): parse current apksigner certificate output

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -188,7 +188,7 @@ jobs:
           if [[ "$BUILD_APK" == true ]]; then
             apk=build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
             "$apksigner" verify --verbose --print-certs "$apk"
-            apk_cert="$("$apksigner" verify --print-certs "$apk" | sed -n 's/^Signer #1 certificate SHA-256 digest: //p' | tr '[:upper:]' '[:lower:]')"
+            apk_cert="$("$apksigner" verify --print-certs "$apk" | sed -n 's/^.*certificate SHA-256 digest: //p' | sed -n '1p' | tr '[:upper:]' '[:lower:]')"
             if [[ "$apk_cert" != "$EXPECTED_CERT_SHA256" ]]; then
               echo "::error::APK signing certificate does not match the production certificate."
               exit 1


### PR DESCRIPTION
Fix Android release verification for current apksigner output. The generated APK already carries the expected production certificate; the previous parser only recognized the older Signer #1 label and therefore compared an empty value. This keeps the certificate equality check intact while accepting the current V2 Signer label.