### PR TITLE
ci(android): build release APK only

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -10,15 +10,6 @@ on:
         description: Existing Android release tag to build
         required: true
         type: string
-      artifact:
-        description: Package format
-        required: true
-        default: both
-        type: choice
-        options:
-          - both
-          - apk
-          - appbundle
 
 permissions:
   contents: read
@@ -46,7 +37,6 @@ jobs:
         shell: bash
         env:
           REQUESTED_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
-          REQUESTED_ARTIFACT: ${{ github.event_name == 'workflow_dispatch' && inputs.artifact || 'both' }}
         run: |
           set -euo pipefail
 
@@ -58,40 +48,10 @@ jobs:
           build_name="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
           build_number="${BASH_REMATCH[4]}"
 
-          case "$REQUESTED_ARTIFACT" in
-            both)
-              build_apk=true
-              build_appbundle=true
-              ;;
-            apk)
-              build_apk=true
-              build_appbundle=false
-              ;;
-            appbundle)
-              build_apk=false
-              build_appbundle=true
-              ;;
-            *)
-              echo "::error::Unsupported package format: $REQUESTED_ARTIFACT"
-              exit 1
-              ;;
-          esac
-
           tag_sha="$(git rev-list -n 1 "$REQUESTED_TAG")"
-          git fetch --no-tags origin main:refs/remotes/origin/main || true
-          git fetch --no-tags origin master:refs/remotes/origin/master || true
-
-          reachable=false
-          for branch in origin/main origin/master; do
-            if git rev-parse --verify --quiet "$branch" >/dev/null &&
-              git merge-base --is-ancestor "$tag_sha" "$branch"; then
-              reachable=true
-              break
-            fi
-          done
-
-          if [[ "$reachable" != true ]]; then
-            echo "::error::Release tag must point to a commit reachable from main or master."
+          git fetch --no-tags origin master:refs/remotes/origin/master
+          if ! git merge-base --is-ancestor "$tag_sha" origin/master; then
+            echo "::error::Release tag must point to a commit reachable from master."
             exit 1
           fi
 
@@ -99,12 +59,10 @@ jobs:
             echo "TAG_NAME=$REQUESTED_TAG"
             echo "BUILD_NAME=$build_name"
             echo "BUILD_NUMBER=$build_number"
-            echo "BUILD_APK=$build_apk"
-            echo "BUILD_APPBUNDLE=$build_appbundle"
           } >> "$GITHUB_ENV"
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: "17"
@@ -137,7 +95,7 @@ jobs:
           test -s "$keystore_path"
           echo "ANDROID_KEYSTORE_PATH=$keystore_path" >> "$GITHUB_ENV"
 
-      - name: Build signed packages
+      - name: Build signed ARM64 APK
         shell: bash
         env:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -156,25 +114,15 @@ jobs:
             fi
           done
 
-          if [[ "$BUILD_APK" == true ]]; then
-            flutter build apk \
-              --release \
-              --no-pub \
-              --split-per-abi \
-              --target-platform android-arm64 \
-              --build-name "$BUILD_NAME" \
-              --build-number "$BUILD_NUMBER"
-          fi
+          flutter build apk \
+            --release \
+            --no-pub \
+            --split-per-abi \
+            --target-platform android-arm64 \
+            --build-name "$BUILD_NAME" \
+            --build-number "$BUILD_NUMBER"
 
-          if [[ "$BUILD_APPBUNDLE" == true ]]; then
-            flutter build appbundle \
-              --release \
-              --no-pub \
-              --build-name "$BUILD_NAME" \
-              --build-number "$BUILD_NUMBER"
-          fi
-
-      - name: Verify signatures and collect artifacts
+      - name: Verify signature and collect APK
         shell: bash
         env:
           EXPECTED_APPLICATION_ID: club.geekpie.techpie
@@ -188,37 +136,24 @@ jobs:
           test -x "$aapt"
           test -x "$apksigner"
 
-          if [[ "$BUILD_APK" == true ]]; then
-            apk=build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
-            apk_application_id="$("$aapt" dump badging "$apk" | sed -n "s/^package: name='\([^']*\)'.*/\1/p")"
-            if [[ "$apk_application_id" != "$EXPECTED_APPLICATION_ID" ]]; then
-              echo "::error::APK application ID does not match the production application ID."
-              exit 1
-            fi
-            "$apksigner" verify --verbose --print-certs "$apk"
-            apk_cert="$("$apksigner" verify --print-certs "$apk" | sed -n 's/^.*certificate SHA-256 digest: //p' | sed -n '1p' | tr '[:upper:]' '[:lower:]')"
-            if [[ "$apk_cert" != "$EXPECTED_CERT_SHA256" ]]; then
-              echo "::error::APK signing certificate does not match the production certificate."
-              exit 1
-            fi
-            cp "$apk" "dist/TechPie-${TAG_NAME}-arm64.apk"
+          apk=build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
+          apk_application_id="$("$aapt" dump badging "$apk" | sed -n "s/^package: name='\([^']*\)'.*/\1/p")"
+          if [[ "$apk_application_id" != "$EXPECTED_APPLICATION_ID" ]]; then
+            echo "::error::APK application ID does not match the production application ID."
+            exit 1
           fi
-
-          if [[ "$BUILD_APPBUNDLE" == true ]]; then
-            appbundle=build/app/outputs/bundle/release/app-release.aab
-            jarsigner -verify "$appbundle"
-            appbundle_cert="$(keytool -printcert -jarfile "$appbundle" | sed -n 's/^[[:space:]]*SHA256: //p' | tr -d ':' | tr '[:upper:]' '[:lower:]' | head -n 1)"
-            if [[ "$appbundle_cert" != "$EXPECTED_CERT_SHA256" ]]; then
-              echo "::error::App Bundle signing certificate does not match the production certificate."
-              exit 1
-            fi
-            cp "$appbundle" "dist/TechPie-${TAG_NAME}.aab"
+          "$apksigner" verify --verbose --print-certs "$apk"
+          apk_cert="$("$apksigner" verify --print-certs "$apk" | sed -n 's/^.*certificate SHA-256 digest: //p' | sed -n '1p' | tr '[:upper:]' '[:lower:]')"
+          if [[ "$apk_cert" != "$EXPECTED_CERT_SHA256" ]]; then
+            echo "::error::APK signing certificate does not match the production certificate."
+            exit 1
           fi
+          cp "$apk" "dist/TechPie-${TAG_NAME}-arm64.apk"
 
-      - name: Upload signed packages
-        uses: actions/upload-artifact@v4
+      - name: Upload signed APK
+        uses: actions/upload-artifact@v7
         with:
           name: TechPie-${{ env.TAG_NAME }}
-          path: dist/*
+          path: dist/*.apk
           if-no-files-found: error
           retention-days: 30


### PR DESCRIPTION
Android 发布工作流只构建正式签名的 ARM64 APK。

- 删除 AAB / both 输入、构建、签名校验与产物收集分支
- 手动重跑只需填写现有 Android tag
- master 是唯一正式发布基线
- 保留 tag 格式、包名与生产证书校验
- 升级到 actions/setup-java@v6、actions/upload-artifact@v7，消除本次正式构建暴露的弃用警告