### PR TITLE
fix(campus): 恢复校园登录并隔离账号缓存

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -70,6 +70,7 @@ Future<void> _realMain(SharedPreferences prefs) async {
     authService,
     storageService,
     thirdPartyAuthService,
+    logger: debugLogger,
   );
   final assignmentService = AssignmentService(
     storageService,

--- a/lib/pages/assignments_page.dart
+++ b/lib/pages/assignments_page.dart
@@ -6,6 +6,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../models/assignment.dart';
 import '../models/assignment_overrides.dart';
+import '../models/third_party_account.dart';
 import '../services/assignment_service.dart';
 import '../services/service_provider.dart';
 import '../utils/adaptive_motion.dart';
@@ -18,6 +19,7 @@ import '../widgets/blurred_app_bar.dart';
 import '../widgets/ios/ios_native_navigation_bar.dart';
 import '../widgets/swipeable_card.dart';
 import 'hidden_assignments_page.dart';
+import 'third_party_bind_page.dart';
 
 class AssignmentsPage extends StatefulWidget {
   const AssignmentsPage({super.key});
@@ -705,6 +707,18 @@ class _PlatformErrorsBanner extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: errors.entries.map((entry) {
+        final tpAuth = ServiceProvider.of(context).thirdPartyAuthService;
+        final platform = switch (entry.key) {
+          'gradescope' => ThirdPartyPlatform.gradescope,
+          'hydro' => ThirdPartyPlatform.hydro,
+          _ => ThirdPartyPlatform.cpdaily,
+        };
+        final node = switch (entry.key) {
+          'blackboard' => tpAuth.elearningNode,
+          'exam' => tpAuth.eamsNode,
+          _ => tpAuth.sessionTree.nodeFor(platform),
+        };
+        final needsLogin = node.lastFailure?.needsLogin == true;
         return Material(
           color: theme.colorScheme.errorContainer,
           child: Padding(
@@ -727,10 +741,23 @@ class _PlatformErrorsBanner extends StatelessWidget {
                   ),
                 ),
                 IconButton(
-                  icon: const Icon(Icons.refresh, size: 20),
-                  onPressed: () => unawaited(service.fetchPlatform(entry.key)),
+                  icon:
+                      Icon(needsLogin ? Icons.login : Icons.refresh, size: 20),
+                  onPressed: service.loading
+                      ? null
+                      : () async {
+                          if (needsLogin) {
+                            final ok = await pushAdaptivePage<bool>(
+                              context,
+                              builder: (_) =>
+                                  ThirdPartyBindPage(platform: platform),
+                            );
+                            if (ok != true) return;
+                          }
+                          await service.fetchPlatform(entry.key);
+                        },
                   color: theme.colorScheme.onErrorContainer,
-                  tooltip: '重试 ${entry.key}',
+                  tooltip: needsLogin ? '重新登录 ${entry.key}' : '重试 ${entry.key}',
                 ),
               ],
             ),

--- a/lib/pages/oa_gym_page.dart
+++ b/lib/pages/oa_gym_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import '../models/oa_gym.dart';
+import '../models/third_party_account.dart';
 import '../services/service_provider.dart';
 import '../utils/platform.dart';
 import '../widgets/adaptive_button.dart';
@@ -15,6 +16,7 @@ import '../widgets/blurred_app_bar.dart';
 import '../widgets/ios/ios_native_navigation_bar.dart';
 import 'login_page.dart';
 import 'third_party_accounts_page.dart';
+import 'third_party_bind_page.dart';
 
 class OaGymPage extends StatefulWidget {
   const OaGymPage({super.key});
@@ -1026,7 +1028,9 @@ class _ProfileTabState extends State<_ProfileTab> {
     // meaning in the OA booking context.
     final displayName = cpdaily?.name?.isNotEmpty == true
         ? cpdaily!.name!
-        : (cpdaily?.account.isNotEmpty == true ? cpdaily!.account : 'TechPie 用户');
+        : (cpdaily?.account.isNotEmpty == true
+            ? cpdaily!.account
+            : 'TechPie 用户');
     final studentId = cpdaily?.sid ?? '';
     final avatarText = displayName.characters.firstOrNull ?? 'U';
 
@@ -1134,12 +1138,32 @@ class _MessageCard extends StatelessWidget {
       color: isError ? scheme.errorContainer : scheme.secondaryContainer,
       child: Padding(
         padding: const EdgeInsets.all(16),
-        child: Text(
-          message,
-          style: TextStyle(
-            color:
-                isError ? scheme.onErrorContainer : scheme.onSecondaryContainer,
-          ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(message,
+                style: TextStyle(
+                    color: isError
+                        ? scheme.onErrorContainer
+                        : scheme.onSecondaryContainer,),),
+            if (isError &&
+                ServiceProvider.of(context)
+                        .thirdPartyAuthService
+                        .cpdailyNode
+                        .lastFailure
+                        ?.needsLogin ==
+                    true)
+              TextButton(
+                onPressed: () => unawaited(
+                  pushAdaptivePage<bool>(
+                    context,
+                    builder: (_) => const ThirdPartyBindPage(
+                        platform: ThirdPartyPlatform.cpdaily,),
+                  ),
+                ),
+                child: const Text('重新登录校园账号'),
+              ),
+          ],
         ),
       ),
     );

--- a/lib/pages/schedule_page.dart
+++ b/lib/pages/schedule_page.dart
@@ -7,6 +7,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../models/course.dart';
 import '../models/course_table.dart';
+import '../models/third_party_account.dart';
 import '../services/calendar/calendar_importer.dart';
 import '../services/ics/ics_export_service.dart';
 import '../services/ics/ics_file_saver.dart';
@@ -27,6 +28,7 @@ import '../widgets/desktop_select_popover.dart';
 import '../widgets/ios/ios_native_navigation_bar.dart';
 import 'login_page.dart';
 import 'third_party_accounts_page.dart';
+import 'third_party_bind_page.dart';
 
 class SchedulePage extends StatefulWidget {
   const SchedulePage({super.key});
@@ -43,6 +45,8 @@ class _SchedulePageState extends State<SchedulePage> {
   int _currentWeek = 1;
   bool _initialized = false;
   bool _exportingCalendar = false;
+  String? _displayedSemester;
+  String? _displayedOwner;
 
   // Settings
   bool _showSaturday = true;
@@ -101,8 +105,13 @@ class _SchedulePageState extends State<SchedulePage> {
   void _rebuildCourses() {
     if (!mounted) return;
     setState(() {
-      _currentWeek =
-          _schedule.currentWeek().clamp(1, _schedule.totalWeeks).toInt();
+      if (_displayedSemester != _schedule.selectedSemesterId ||
+          _displayedOwner != _schedule.owner) {
+        _currentWeek = _schedule.currentWeek();
+        _displayedSemester = _schedule.selectedSemesterId;
+        _displayedOwner = _schedule.owner;
+      }
+      _currentWeek = _currentWeek.clamp(1, _schedule.totalWeeks).toInt();
       final table = _schedule.courseTable;
       if (table != null) {
         if (table.periods.isNotEmpty) {
@@ -814,7 +823,9 @@ class _SchedulePageState extends State<SchedulePage> {
                 height: 300,
                 child: Center(
                   child: Text(
-                    '本周没有课程',
+                    _schedule.courseTable == null
+                        ? (_schedule.loading ? '正在获取课表…' : '课表尚未获取成功')
+                        : '本周没有课程',
                     style: theme.textTheme.bodyLarge?.copyWith(
                       color: theme.colorScheme.onSurfaceVariant,
                     ),
@@ -834,6 +845,33 @@ class _SchedulePageState extends State<SchedulePage> {
 
     return Column(
       children: [
+        if (_schedule.error != null)
+          ListTile(
+            dense: true,
+            title: Text(_schedule.error!),
+            subtitle: _schedule.updatedAt == null
+                ? null
+                : Text(
+                    '显示上次成功同步的课表 · ${_schedule.updatedAt!.toLocal().toString().substring(0, 16)}',
+                  ),
+            trailing: TextButton(
+              onPressed: _schedule.loading
+                  ? null
+                  : () async {
+                      if (_schedule.failure?.needsLogin == true) {
+                        final ok = await pushAdaptivePage<bool>(
+                          context,
+                          builder: (_) => const ThirdPartyBindPage(
+                              platform: ThirdPartyPlatform.cpdaily,),
+                        );
+                        if (ok != true || !mounted) return;
+                      }
+                      await _refresh();
+                    },
+              child:
+                  Text(_schedule.failure?.needsLogin == true ? '重新登录' : '重试'),
+            ),
+          ),
         _DayHeader(
           weekStart: _weekStartForWeek(week),
           today: today,

--- a/lib/pages/third_party_accounts_page.dart
+++ b/lib/pages/third_party_accounts_page.dart
@@ -12,7 +12,6 @@ import '../widgets/adaptive_page_navigation.dart';
 import '../widgets/app_shell/app_shell_metrics.dart';
 import '../widgets/blurred_app_bar.dart';
 import '../widgets/ios/ios_native_navigation_bar.dart';
-import 'login_page.dart';
 import 'third_party_bind_page.dart';
 
 class ThirdPartyAccountsPage extends StatelessWidget {
@@ -52,7 +51,7 @@ class ThirdPartyAccountsPage extends StatelessWidget {
             )
           : const BlurredAppBar(title: Text('Linked Accounts')),
       body: ListenableBuilder(
-        listenable: Listenable.merge([tpAuth, auth]),
+        listenable: Listenable.merge([tpAuth, auth, tpAuth.elearningNode]),
         builder: (context, _) {
           return ListView(
             padding: EdgeInsets.only(
@@ -77,7 +76,7 @@ class ThirdPartyAccountsPage extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: Text(
                   '绑定信息加密存储于设备本地 Keychain / EncryptedSharedPreferences,'
-                  '不会上传到服务器。',
+                  '开启云同步后会按同步设置加密备份。',
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -94,23 +93,28 @@ class ThirdPartyAccountsPage extends StatelessWidget {
 class _BlackboardTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final auth = ServiceProvider.of(context).authService;
-    final theme = Theme.of(context);
-    final loggedIn = auth.isLoggedIn;
-
+    final tpAuth = ServiceProvider.of(context).thirdPartyAuthService;
+    final verified = tpAuth.elearningNode.verifiedAt != null;
     return ListTile(
       leading: const Icon(Icons.school_outlined),
       title: const Text('Blackboard'),
       subtitle: Text(
-        loggedIn
-            ? '通过主账号自动启用 (CASTGC) · ${auth.session!.studentId.isNotEmpty ? auth.session!.studentId : auth.session!.userId}'
-            : '登录主账号后自动启用',
-        style: theme.textTheme.bodySmall,
+        !tpAuth.hasCpdailyBinding
+            ? '需要绑定 CpDaily / IDS'
+            : verified
+                ? '最近一次同步成功'
+                : '通过校园账号访问，尚未验证同步',
       ),
-      trailing: loggedIn
-          ? Icon(Icons.check_circle, color: theme.colorScheme.primary, size: 20)
+      trailing: verified
+          ? const Icon(Icons.check_circle_outline)
           : const Icon(Icons.chevron_right),
-      onTap: loggedIn ? null : () => unawaited(presentLoginPage(context)),
+      onTap: () => unawaited(
+        pushAdaptivePage<bool>(
+          context,
+          builder: (_) =>
+              const ThirdPartyBindPage(platform: ThirdPartyPlatform.cpdaily),
+        ),
+      ),
     );
   }
 }
@@ -139,7 +143,7 @@ class _ThirdPartyTile extends StatelessWidget {
         subtitle: const Text('未绑定'),
         trailing: const Icon(Icons.chevron_right),
         onTap: () => unawaited(
-          pushAdaptivePage<void>(
+          pushAdaptivePage<bool>(
             context,
             builder: (_) => ThirdPartyBindPage(platform: platform),
           ),
@@ -149,6 +153,7 @@ class _ThirdPartyTile extends StatelessWidget {
 
     final subtitleParts = <String>[
       acc.displayName,
+      '点击重新登录',
       if (acc.expireAt != null) _expireLabel(acc.expireAt!),
       if (acc.autoRenew) '自动更新 Token 已开启',
     ];
@@ -163,6 +168,12 @@ class _ThirdPartyTile extends StatelessWidget {
       title: Text(platform.label),
       subtitle: Text(subtitleParts.join('\n')),
       isThreeLine: subtitleParts.length > 1,
+      onTap: () => unawaited(
+        pushAdaptivePage<bool>(
+          context,
+          builder: (_) => ThirdPartyBindPage(platform: platform),
+        ),
+      ),
       trailing: isIos()
           ? AdaptiveConfirmationButton(
               label: 'Unbind',

--- a/lib/pages/third_party_bind_page.dart
+++ b/lib/pages/third_party_bind_page.dart
@@ -40,12 +40,28 @@ class _ThirdPartyBindPageState extends State<ThirdPartyBindPage> {
   String? _inlineError;
 
   // cpdaily SMS state
-  int _cpdailyLoginMethod = 0; // 0 = password, 1 = SMS
+  int _cpdailyLoginMethod = 1; // 0 = password, 1 = SMS
   final _cpdailyPhoneCtrl = TextEditingController();
   final _cpdailyCodeCtrl = TextEditingController();
   bool _sendingSms = false;
   int _smsCooldown = 0;
   Timer? _smsCooldownTimer;
+  ThirdPartyAuthService? _tpAuth;
+  String _smsPhone = '';
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_tpAuth != null) return;
+    _tpAuth = ServiceProvider.of(context).thirdPartyAuthService;
+    _cpdailyPhoneCtrl.addListener(() {
+      final phone = _cpdailyPhoneCtrl.text.trim();
+      if (phone == _smsPhone) return;
+      _smsPhone = phone;
+      _tpAuth!.cancelCpdailySms();
+      _cpdailyCodeCtrl.clear();
+    });
+  }
 
   bool get _isHydro => widget.platform == ThirdPartyPlatform.hydro;
   bool get _isGradescope => widget.platform == ThirdPartyPlatform.gradescope;
@@ -60,6 +76,7 @@ class _ThirdPartyBindPageState extends State<ThirdPartyBindPage> {
 
   @override
   void dispose() {
+    if (_isCpdaily) _tpAuth?.cancelCpdailySms();
     _accountCtrl.dispose();
     _passwordCtrl.dispose();
     _hydroOriginCtrl.dispose();
@@ -186,7 +203,7 @@ class _ThirdPartyBindPageState extends State<ThirdPartyBindPage> {
           style: AdaptiveFeedbackStyle.success,
         );
       }
-      await maybePopAdaptivePage<void>(context);
+      await maybePopAdaptivePage<bool>(context, true);
     } on ThirdPartyBindException catch (e) {
       if (!mounted) return;
       if (isIos()) {

--- a/lib/services/assignment_service.dart
+++ b/lib/services/assignment_service.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -12,6 +11,7 @@ import 'api_base_url.dart';
 import 'auth_service.dart';
 import 'http_client.dart';
 import 'schedule_service.dart';
+import 'session/session_failure.dart';
 import 'session/session_tree.dart';
 import 'storage_service.dart';
 import 'third_party_auth_service.dart';
@@ -67,6 +67,24 @@ class AssignmentService extends ChangeNotifier {
   }
 
   bool _autoRefetchEnabled = false;
+  bool _pendingBindingFetch = false;
+  int _request = 0;
+  String? _bindingStamp;
+  String get _currentStamp => '${_auth.isLoggedIn}:'
+      '${_tpAuth.cpdailyNode.generation}:${_tpAuth.gradescopeNode.generation}:'
+      '${_tpAuth.hydroNode.generation}';
+  Map<String, String> get _owners => {
+        if (_tpAuth.cpdailyNode.identityKey case final String owner) ...{
+          'blackboard': '$owner:blackboard',
+          'exam': '$owner:exam:${_schedule.selectedSemesterId ?? ""}',
+        },
+        if (_tpAuth.gradescopeNode.identityKey case final String owner)
+          'gradescope': owner,
+        if (_tpAuth.hydroNode.identityKey case final String owner)
+          'hydro': '$owner:${_tpAuth.hydroNode.account?.hydroOrigin ?? ""}',
+      };
+  String get _overrideOwner => jsonEncode(_owners);
+
   // Track the last semester we refetched for, so schedule notifies that
   // don't change the semester (loading flips, course_table updates, errors)
   // do NOT trigger a redundant assignment refetch.
@@ -76,6 +94,7 @@ class AssignmentService extends ChangeNotifier {
   /// explicit fetch from app boot has been kicked off.
   void enableAutoRefetch() {
     _autoRefetchEnabled = true;
+    _bindingStamp = _currentStamp;
     // Seed so the first schedule notify (which doesn't change the semester)
     // doesn't trigger a redundant refetch of the same semester.
     _lastRefetchedSemesterId = _schedule.selectedSemesterId;
@@ -83,8 +102,16 @@ class AssignmentService extends ChangeNotifier {
 
   /// Auth or binding changed — always refetch (tokens, accounts differ).
   void _onBindingsOrAuthChanged() {
-    if (!_autoRefetchEnabled) return;
+    if (!_autoRefetchEnabled || _bindingStamp == _currentStamp) return;
+    _bindingStamp = _currentStamp;
+    _request++;
+    _loading = false;
+    loadCached();
     _lastRefetchedSemesterId = _schedule.selectedSemesterId;
+    if (_schedule.suppressAssignmentRefetch) {
+      _pendingBindingFetch = true;
+      return;
+    }
     unawaited(fetchAssignments());
   }
 
@@ -99,8 +126,14 @@ class AssignmentService extends ChangeNotifier {
     if (!_autoRefetchEnabled) return;
     if (_schedule.suppressAssignmentRefetch) return;
     final currentSemester = _schedule.selectedSemesterId;
-    if (currentSemester == _lastRefetchedSemesterId) return;
+    if (currentSemester == _lastRefetchedSemesterId && !_pendingBindingFetch) {
+      return;
+    }
+    _pendingBindingFetch = false;
     _lastRefetchedSemesterId = currentSemester;
+    _request++;
+    _loading = false;
+    loadCached();
     unawaited(fetchAssignments());
   }
 
@@ -112,34 +145,37 @@ class AssignmentService extends ChangeNotifier {
     super.dispose();
   }
 
-
   /// Clear cached + in-memory deadlines (called on primary logout).
   Future<void> clearCache() async {
+    _request++;
+    _loading = false;
     _assignments = [];
     _platformErrors.clear();
     _error = null;
-    await _storage.clearCachedAssignments();
+    for (final owner in _owners.values) {
+      await _storage.clearCachedAssignments(owner: owner);
+    }
     notifyListeners();
   }
 
-  /// Hydrate from local cache so the UI doesn't flash empty on app start
-  /// or tab switch. Safe to call before login. Also loads overrides.
   void loadCached() {
-    _overrides = _storage.loadAssignmentOverrides();
-    final raw = _storage.loadCachedAssignments();
-    if (raw.isEmpty) {
-      notifyListeners();
-      return;
-    }
-    _assignments = raw.map((e) => Assignment.fromJson(e)).toList()
-      ..sort((a, b) => a.due.compareTo(b.due));
+    _platformErrors.clear();
+    _error = null;
+    _overrides = _storage.loadAssignmentOverrides(owner: _overrideOwner);
+    _assignments = [
+      for (final entry in _owners.entries)
+        ..._storage
+            .loadCachedAssignments(owner: entry.value)
+            .map(Assignment.fromJson)
+            .where((a) => a.platform.toLowerCase() == entry.key),
+    ]..sort((a, b) => a.due.compareTo(b.due));
     notifyListeners();
   }
 
   // -- Override mutators --
 
   Future<void> _persistOverrides() =>
-      _storage.saveAssignmentOverrides(_overrides);
+      _storage.saveAssignmentOverrides(_overrides, owner: _overrideOwner);
 
   Future<void> setCompleted(Assignment a, bool completed) async {
     _overrides.completed[AssignmentOverrides.keyFor(a)] = completed;
@@ -190,7 +226,7 @@ class AssignmentService extends ChangeNotifier {
 
   Future<void> clearAllOverrides() async {
     _overrides = AssignmentOverrides();
-    await _storage.clearAssignmentOverrides();
+    await _persistOverrides();
     notifyListeners();
   }
 
@@ -198,140 +234,62 @@ class AssignmentService extends ChangeNotifier {
         'Content-Type': 'application/json; charset=UTF-8',
       };
 
-  Future<void> fetchAssignments() async {
-    if (_loading) return; // 避免启动时 listener 链触发的并发重复调用
+  Future<void> fetchAssignments([String? onlyPlatform]) async {
+    if (_loading) return;
+    final request = ++_request;
+    final owners = _owners;
     _loading = true;
     _error = null;
-    _platformErrors.clear();
-    notifyListeners();
-
-    final successfulResults = <String, List<Assignment>>{};
-
-    final futures = <Future<void>>[];
-
-    if (_tpAuth.hasCpdailyBinding) {
-      futures.add(
-        _fetchBlackboard().then((items) {
-          if (items != null) successfulResults['blackboard'] = items;
-        }),
-      );
-      futures.add(
-        _fetchExamTable().then((items) {
-          if (items != null) successfulResults['exam'] = items;
-        }),
-      );
-    }
-
-    for (final acc in _tpAuth.accounts) {
-      switch (acc.platform) {
-        case ThirdPartyPlatform.gradescope:
-          futures.add(
-            _fetchGradescope(acc).then((items) {
-              if (items != null) successfulResults[acc.platform.id] = items;
-            }),
-          );
-          break;
-        case ThirdPartyPlatform.hydro:
-          futures.add(
-            _fetchHydro(acc).then((items) {
-              if (items != null) successfulResults[acc.platform.id] = items;
-            }),
-          );
-          break;
-        case ThirdPartyPlatform.cpdaily:
-          // cpdaily provides the CpDaily session, not deadline data — skip.
-          break;
-      }
-    }
-
-    try {
-      await Future.wait(futures);
-      final merged = _mergeAssignments(
-        successfulResults: successfulResults,
-      );
-
-      _assignments = merged;
-      await _storage.saveCachedAssignments(
-        merged.map((a) => a.toJson()).toList(),
-      );
-    } catch (e) {
-      _error = '同步失败，请检查网络或稍后重试';
-    } finally {
-      _loading = false;
-      notifyListeners();
-    }
-  }
-
-  List<Assignment> _mergeAssignments({
-    required Map<String, List<Assignment>> successfulResults,
-  }) {
-    final successfulPlatforms =
-        successfulResults.keys.map((p) => p.toLowerCase()).toSet();
-
-    final merged = <Assignment>[
-      for (final a in _assignments)
-        if (!successfulPlatforms.contains(a.platform.toLowerCase())) a,
-      ...successfulResults.values.expand((items) => items),
-    ]..sort((a, b) => a.due.compareTo(b.due));
-
-    return merged;
-  }
-
-  Future<void> fetchPlatform(String platformId) async {
-    _loading = true;
-    _error = null;
-    _platformErrors.remove(platformId);
-    notifyListeners();
-
-    final successfulResults = <String, List<Assignment>>{};
-    Future<void>? future;
-
-    if (platformId == 'blackboard' && _tpAuth.hasCpdailyBinding) {
-      future = _fetchBlackboard().then((items) {
-        if (items != null) successfulResults['blackboard'] = items;
-      });
-    } else if (platformId == 'exam' && _tpAuth.hasCpdailyBinding) {
-      future = _fetchExamTable().then((items) {
-        if (items != null) successfulResults['exam'] = items;
-      });
+    if (onlyPlatform == null) {
+      _platformErrors.clear();
     } else {
-      for (final acc in _tpAuth.accounts) {
-        if (acc.platform.id == platformId) {
-          if (acc.platform == ThirdPartyPlatform.gradescope) {
-            future = _fetchGradescope(acc).then((items) {
-              if (items != null) successfulResults[platformId] = items;
-            });
-          } else if (acc.platform == ThirdPartyPlatform.hydro) {
-            future = _fetchHydro(acc).then((items) {
-              if (items != null) successfulResults[platformId] = items;
-            });
-          }
-          break;
-        }
-      }
+      _platformErrors.remove(onlyPlatform);
     }
-
-    if (future != null) {
-      try {
-        await future;
-        final merged = _mergeAssignments(
-          successfulResults: successfulResults,
-        );
-
-        _assignments = merged;
-        await _storage.saveCachedAssignments(
-          merged.map((a) => a.toJson()).toList(),
-        );
-      } catch (e) {
-        _error = e.toString();
-      }
-    }
-
-    _loading = false;
     notifyListeners();
+    try {
+      final results = <String, List<Assignment>>{};
+      await Future.wait(
+        owners.keys
+            .where((p) => onlyPlatform == null || p == onlyPlatform)
+            .map((p) async {
+          final items = switch (p) {
+            'blackboard' => await _fetchBlackboard(),
+            'exam' => await _fetchExamTable(),
+            'gradescope' =>
+              await _fetchGradescope(_tpAuth.gradescopeNode.account!),
+            'hydro' => await _fetchHydro(_tpAuth.hydroNode.account!),
+            _ => null,
+          };
+          if (items != null) results[p] = items;
+        }),
+      );
+      if (request != _request) return;
+      // Failed platforms keep their last successful data, including on 401.
+      _assignments = [
+        for (final a in _assignments)
+          if (!results.containsKey(a.platform.toLowerCase())) a,
+        ...results.values.expand((items) => items),
+      ]..sort((a, b) => a.due.compareTo(b.due));
+      for (final entry in results.entries) {
+        await _storage.saveCachedAssignments(
+          entry.value.map((a) => a.toJson()).toList(),
+          owner: owners[entry.key],
+        );
+      }
+    } catch (_) {
+      if (request == _request) _error = '同步失败，请稍后重试';
+    } finally {
+      if (request == _request) {
+        _loading = false;
+        notifyListeners();
+      }
+    }
   }
+
+  Future<void> fetchPlatform(String platformId) => fetchAssignments(platformId);
 
   Future<List<Assignment>?> _fetchBlackboard() async {
+    final request = _request;
     final node = _tpAuth.elearningNode;
     // withCookie handles initial minting if the downstream cookie isn't set.
     if (!_tpAuth.hasCpdailyBinding) return null;
@@ -352,15 +310,22 @@ class AssignmentService extends ChangeNotifier {
           return CookieAction(r, expired: r.statusCode == 401);
         },
       );
-      if (resp == null) return null;
-      return _parseDeadlinesResponse(resp, 'blackboard');
+      if (request != _request) return null;
+      if (resp == null) throw node.lastFailure ?? SessionFailure.unavailable;
+      final items = _parseDeadlinesResponse(resp, 'blackboard');
+      if (items != null) node.markVerified();
+      return items;
     } catch (e) {
-      _platformErrors['blackboard'] = '同步失败，请检查网络或稍后重试';
+      if (request == _request) {
+        _platformErrors['blackboard'] =
+            e is SessionFailure ? e.message : '同步失败，请稍后重试';
+      }
       return null;
     }
   }
 
   Future<List<Assignment>?> _fetchExamTable() async {
+    final request = _request;
     final semesterId = _selectedSemesterId();
     final node = _tpAuth.eamsNode;
     if (!_tpAuth.hasCpdailyBinding ||
@@ -385,15 +350,20 @@ class AssignmentService extends ChangeNotifier {
           return CookieAction(r, expired: r.statusCode == 401);
         },
       );
-      if (resp == null) return null;
+      if (request != _request) return null;
+      if (resp == null) throw node.lastFailure ?? SessionFailure.unavailable;
       return _parseExamTableResponse(resp);
     } catch (e) {
-      _platformErrors['exam'] = '同步失败，请检查网络或稍后重试';
+      if (request == _request) {
+        _platformErrors['exam'] =
+            e is SessionFailure ? e.message : '同步失败，请稍后重试';
+      }
       return null;
     }
   }
 
   Future<List<Assignment>?> _fetchGradescope(ThirdPartyAccount acc) async {
+    final request = _request;
     final node = _tpAuth.gradescopeNode;
     if (!node.isAvailable) return null;
     try {
@@ -410,20 +380,21 @@ class AssignmentService extends ChangeNotifier {
           return CookieAction(r, expired: r.statusCode == 401);
         },
       );
-      if (resp == null) return null;
-      if (resp.statusCode == 401) {
-        await _tpAuth.unbind(ThirdPartyPlatform.gradescope);
-        _platformErrors['gradescope'] = 'token 已失效,请重新绑定';
-        return null;
-      }
+      if (request != _request) return null;
+      if (resp == null) throw node.lastFailure ?? SessionFailure.unavailable;
+
       return _parseDeadlinesResponse(resp, 'gradescope');
     } catch (e) {
-      _platformErrors['gradescope'] = '同步失败，请检查网络或稍后重试';
+      if (request == _request) {
+        _platformErrors['gradescope'] =
+            e is SessionFailure ? e.message : '同步失败，请稍后重试';
+      }
       return null;
     }
   }
 
   Future<List<Assignment>?> _fetchHydro(ThirdPartyAccount acc) async {
+    final request = _request;
     final origin = acc.hydroOrigin ?? 'https://acm.shanghaitech.edu.cn';
     final domains = acc.hydroDomains ?? const <String>[];
     if (domains.isEmpty) {
@@ -450,17 +421,14 @@ class AssignmentService extends ChangeNotifier {
                 'token': cp.cookies,
                 'args': {'url': url},
               }),
-              tag: 'deadlines:hydro:$domain',
+              tag: 'deadlines:hydro',
             );
             return CookieAction(r, expired: r.statusCode == 401);
           },
         );
-        if (resp == null) return null;
-        if (resp.statusCode == 401) {
-          await _tpAuth.unbind(ThirdPartyPlatform.hydro);
-          _platformErrors['hydro'] = 'token 已失效,请重新绑定';
-          return null;
-        }
+        if (request != _request) return null;
+        if (resp == null) throw node.lastFailure ?? SessionFailure.unavailable;
+
         final items = _parseDeadlinesResponse(resp, 'hydro');
         if (items != null) {
           all.addAll(items);
@@ -468,7 +436,10 @@ class AssignmentService extends ChangeNotifier {
           hadError = true;
         }
       } catch (e) {
-        _platformErrors['hydro'] = '同步失败，请检查网络或稍后重试';
+        if (request == _request) {
+          _platformErrors['hydro'] =
+              e is SessionFailure ? e.message : '同步失败，请稍后重试';
+        }
         hadError = true;
       }
     }
@@ -490,11 +461,15 @@ class AssignmentService extends ChangeNotifier {
 
     if (resp.statusCode != 200 || data['success'] != true) {
       _platformErrors[platformKey] =
-          (data['error'] as String?) ?? '同步失败 (HTTP ${resp.statusCode})';
+          SessionFailure.fromStatus(resp.statusCode).message;
       return null;
     }
 
-    final raw = data['data'] as List<dynamic>? ?? const [];
+    if (data['data'] is! List) {
+      _platformErrors[platformKey] = '服务返回异常，请稍后重试';
+      return null;
+    }
+    final raw = data['data'] as List<dynamic>;
     return raw
         .map((e) => Assignment.fromJson(e as Map<String, dynamic>))
         .toList();
@@ -511,7 +486,7 @@ class AssignmentService extends ChangeNotifier {
 
     if (resp.statusCode != 200 || data['success'] != true) {
       _platformErrors['exam'] =
-          (data['error'] as String?) ?? '同步失败 (HTTP ${resp.statusCode})';
+          SessionFailure.fromStatus(resp.statusCode).message;
       return null;
     }
 
@@ -522,7 +497,11 @@ class AssignmentService extends ChangeNotifier {
     final batchName = payload['examBatchName']?.toString() ?? '考试';
     final semesterId =
         payload['semesterId']?.toString() ?? _selectedSemesterId() ?? '';
-    final raw = payload['exams'] as List<dynamic>? ?? const [];
+    if (payload['exams'] is! List) {
+      _platformErrors['exam'] = '服务返回异常，请稍后重试';
+      return null;
+    }
+    final raw = payload['exams'] as List<dynamic>;
 
     return raw
         .map((exam) => exam is Map ? exam.cast<String, dynamic>() : null)
@@ -603,7 +582,5 @@ class AssignmentService extends ChangeNotifier {
   }
 
   String? _selectedSemesterId() =>
-      _schedule.selectedSemesterId ??
-      _storage.selectedSemester ??
-      _schedule.semesterInfo?.defaultSemester;
+      _schedule.selectedSemesterId ?? _schedule.semesterInfo?.defaultSemester;
 }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -67,12 +67,15 @@ class AuthService extends ChangeNotifier {
 
     try {
       final tokens = await _uniAuth.refresh(refreshToken);
-      _session = session.copyWith(
+      if (!identical(_session, session)) return false;
+      final renewed = session.copyWith(
         geekpieToken: tokens.accessToken,
         geekpieExpiresAt: tokens.expiresAt ?? session.geekpieExpiresAt,
         geekpieRefreshToken: tokens.refreshToken ?? refreshToken,
       );
-      await _storage.saveSession(_session!);
+      _session = renewed;
+      await _storage.saveSession(renewed);
+      if (!identical(_session, renewed)) return false;
       notifyListeners();
       return true;
     } catch (_) {
@@ -125,8 +128,8 @@ class AuthService extends ChangeNotifier {
   // -- Logout --
 
   Future<void> logout() async {
-    await _storage.clearSession();
     _session = null;
+    await _storage.clearSession();
     if (onLogout != null) {
       try {
         await onLogout!();

--- a/lib/services/debug_logger.dart
+++ b/lib/services/debug_logger.dart
@@ -11,6 +11,7 @@ class LogEntry {
   final String? responseBody;
   final String? error;
   final String? tag;
+  final int? elapsedMs;
 
   LogEntry({
     required this.timestamp,
@@ -21,6 +22,7 @@ class LogEntry {
     this.responseBody,
     this.error,
     this.tag,
+    this.elapsedMs,
   });
 }
 
@@ -46,6 +48,7 @@ class DebugLogger extends ChangeNotifier {
     String? responseBody,
     String? error,
     String? tag,
+    int? elapsedMs,
   }) {
     if (!_enabled) return;
     if (_entries.length >= _maxEntries) {
@@ -60,19 +63,28 @@ class DebugLogger extends ChangeNotifier {
       responseBody: redactSensitive(responseBody),
       error: error,
       tag: tag,
+      elapsedMs: elapsedMs,
     );
     _entries.add(entry);
     notifyListeners();
     if (kDebugMode) {
       debugPrint(
         '[HTTP] ${entry.method} ${entry.url} '
-        '${entry.statusCode ?? '—'} ${entry.tag ?? ''}',
+        '${entry.statusCode ?? '—'} ${entry.tag ?? ''} ${entry.elapsedMs ?? 0}ms ${entry.error ?? ''}',
       );
     }
   }
 
   static const _sensitiveKeys = {
     'password',
+    'phone',
+    'mobile',
+    'code',
+    'chk',
+    'fhk',
+    'ticket',
+    'secretKey',
+    'authorization',
     'token',
     'tgc',
     'sessionToken',

--- a/lib/services/http_client.dart
+++ b/lib/services/http_client.dart
@@ -16,22 +16,26 @@ class LoggingHttpClient {
     Map<String, String>? headers,
     String? tag,
   }) async {
-    _logger.log(method: 'GET', url: url.toString(), tag: tag);
+    final timer = Stopwatch()..start();
+    _logger.log(method: 'GET', url: url.origin, tag: tag);
     try {
-      final response = await _inner.get(url, headers: headers);
+      final response = await _inner
+          .get(url, headers: headers)
+          .timeout(const Duration(seconds: 30));
       _logger.log(
         method: 'GET',
-        url: url.toString(),
+        url: url.origin,
         statusCode: response.statusCode,
-        responseBody: _truncate(response.body),
+        elapsedMs: timer.elapsedMilliseconds,
         tag: tag,
       );
       return response;
     } catch (e) {
       _logger.log(
         method: 'GET',
-        url: url.toString(),
-        error: e.toString(),
+        url: url.origin,
+        error: e.runtimeType.toString(),
+        elapsedMs: timer.elapsedMilliseconds,
         tag: tag,
       );
       rethrow;
@@ -45,42 +49,42 @@ class LoggingHttpClient {
     Encoding? encoding,
     String? tag,
   }) async {
+    final timer = Stopwatch()..start();
     final bodyStr =
         body is String ? body : (body != null ? jsonEncode(body) : null);
     _logger.log(
       method: 'POST',
-      url: url.toString(),
-      requestBody: bodyStr,
+      url: url.origin,
       tag: tag,
     );
     try {
-      final response = await _inner.post(
-        url,
-        headers: headers,
-        body: bodyStr,
-        encoding: encoding,
-      );
+      final response = await _inner
+          .post(
+            url,
+            headers: headers,
+            body: bodyStr,
+            encoding: encoding,
+          )
+          .timeout(const Duration(seconds: 30));
       _logger.log(
         method: 'POST',
-        url: url.toString(),
+        url: url.origin,
         statusCode: response.statusCode,
-        responseBody: _truncate(response.body),
+        elapsedMs: timer.elapsedMilliseconds,
         tag: tag,
       );
       return response;
     } catch (e) {
       _logger.log(
         method: 'POST',
-        url: url.toString(),
-        error: e.toString(),
+        url: url.origin,
+        error: e.runtimeType.toString(),
+        elapsedMs: timer.elapsedMilliseconds,
         tag: tag,
       );
       rethrow;
     }
   }
-
-  String _truncate(String s, [int maxLen = 2000]) =>
-      s.length > maxLen ? '${s.substring(0, maxLen)}...' : s;
 
   void close() => _inner.close();
 }

--- a/lib/services/oa_gym_service.dart
+++ b/lib/services/oa_gym_service.dart
@@ -6,7 +6,10 @@ import 'package:http/http.dart' as http;
 import '../models/oa_gym.dart';
 import 'api_base_url.dart';
 import 'auth_service.dart';
+import 'debug_logger.dart';
+import 'http_client.dart';
 import 'session/cookie_provider.dart';
+import 'session/session_failure.dart';
 import 'session/session_tree.dart';
 import 'storage_service.dart';
 import 'third_party_auth_service.dart';
@@ -23,7 +26,8 @@ class OaGymService extends ChangeNotifier {
   final AuthService _auth;
   final StorageService _storage;
   final ThirdPartyAuthService _tpAuth;
-  final http.Client _client;
+  final LoggingHttpClient _client;
+  int _generation = -1;
 
   bool _sessionReady = false;
   bool _metadataReady = false;
@@ -37,7 +41,24 @@ class OaGymService extends ChangeNotifier {
     this._storage,
     this._tpAuth, {
     http.Client? client,
-  }) : _client = client ?? http.Client();
+    DebugLogger? logger,
+  }) : _client = LoggingHttpClient(logger ?? DebugLogger(), inner: client) {
+    _tpAuth.addListener(_onBindingChanged);
+  }
+
+  void _onBindingChanged() {
+    final generation = _tpAuth.cpdailyNode.generation;
+    if (_generation == generation) return;
+    _generation = generation;
+    clearSession();
+  }
+
+  @override
+  void dispose() {
+    _tpAuth.removeListener(_onBindingChanged);
+    _client.close();
+    super.dispose();
+  }
 
   String get _baseUrl => apiBaseUrl(_storage);
 
@@ -263,7 +284,7 @@ class OaGymService extends ChangeNotifier {
       'tgc': (raw['tgc'] as String?) ?? '',
       'cookies': cp.cookies,
       'sessionToken': (raw['sessionToken'] as String?) ?? '',
-      'userId': (raw['userId'] as String?) ?? '',
+      'userId': (raw['userId'] as String?) ?? cp.studentId,
       'tenantId': (raw['tenantId'] as String?) ?? '',
     };
   }
@@ -277,39 +298,54 @@ class OaGymService extends ChangeNotifier {
   ) async {
     _requireAuth();
     final node = _tpAuth.cpdailyNode;
-    final response = await _tpAuth.sessionTree.withCookie<http.Response>(
-      node,
-      (cp) async {
-        final body = {...extra, 'auth': _authPayload(cp)};
-        final r = await _client
-            .post(
-              Uri.parse('$_baseUrl/$path'),
-              headers: const {
-                'Content-Type': 'application/json; charset=UTF-8',
-              },
-              body: jsonEncode(body),
-            )
-            .timeout(const Duration(seconds: 30));
-        return CookieAction(r, expired: r.statusCode == 401);
-      },
-    );
-    if (response == null) {
-      throw OaGymException('当前 eGate 登录态已失效，请重新绑定 eGate');
+    final generation = node.generation;
+    final submitting = path == 'oa/gym/book';
+    Future<CookieAction<http.Response>> send(CookieProvider cp) async {
+      final response = await _client.post(
+        Uri.parse('$_baseUrl/$path'),
+        headers: const {'Content-Type': 'application/json; charset=UTF-8'},
+        body: jsonEncode({...extra, 'auth': _authPayload(cp)}),
+        tag: path,
+      );
+      return CookieAction(response, expired: response.statusCode == 401);
     }
-    if (response.statusCode == 401) {
-      _sessionReady = false;
-    }
-    final decoded = response.body.isEmpty
-        ? <String, dynamic>{}
-        : (jsonDecode(response.body) as Map).cast<String, dynamic>();
-    if (response.statusCode < 200 ||
-        response.statusCode >= 300 ||
-        decoded['success'] == false) {
+
+    try {
+      // Submission is sent once. A timeout cannot tell whether OA accepted it.
+      final http.Response? response;
+      if (submitting) {
+        final cp = node.cookieProvider;
+        if (cp == null) throw SessionFailure.fromStatus(401);
+        response = (await send(cp)).value;
+      } else {
+        response =
+            await _tpAuth.sessionTree.withCookie<http.Response>(node, send);
+      }
+      if (generation != node.generation) throw SessionFailure.changed;
+      if (response == null) {
+        throw node.lastFailure ?? SessionFailure.unavailable;
+      }
+      if (response.statusCode != 200) {
+        throw SessionFailure.fromStatus(response.statusCode);
+      }
+      final decoded =
+          (jsonDecode(response.body) as Map).cast<String, dynamic>();
+      if (decoded['success'] != true) throw SessionFailure.unavailable;
+      node.lastFailure = null;
+      return decoded;
+    } catch (error) {
+      final failure =
+          error is SessionFailure ? error : SessionFailure.unavailable;
+      if (generation == node.generation) {
+        node.lastFailure = failure;
+        if (failure.needsLogin) _sessionReady = false;
+      }
       throw OaGymException(
-        decoded['error'] as String? ?? 'OA 场馆服务请求失败，请稍后重试',
+        submitting && !failure.needsLogin
+            ? '未能确认预约结果，请先在 OA 查看预约记录，确认后再提交'
+            : failure.message,
       );
     }
-    return decoded;
   }
 
   Map<String, String> _stringMap(Object? value) {

--- a/lib/services/schedule_service.dart
+++ b/lib/services/schedule_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -8,6 +9,7 @@ import 'api_base_url.dart';
 import 'auth_service.dart';
 import 'http_client.dart';
 import 'session/cookie_provider.dart';
+import 'session/session_failure.dart';
 import 'session/session_tree.dart';
 import 'storage_service.dart';
 import 'third_party_auth_service.dart';
@@ -16,283 +18,202 @@ class ScheduleService extends ChangeNotifier {
   final StorageService _storage;
   final LoggingHttpClient _http;
   final ThirdPartyAuthService _tpAuth;
-
   SemesterInfo? _semesterInfo;
   CourseTable? _courseTable;
   TermCalendar? _termCalendar;
   String? _selectedSemesterId;
+  String? _owner;
+  int _generation = -1;
+  int _request = 0;
+  bool _ready = false;
   bool _loading = false;
-  String? _error;
-  // While true, AssignmentService should NOT refetch on our notifies —
-  // selectSemester sets this during its own network fetch to avoid a
-  // concurrent exam_table + course_table race on EAMS's stateful session.
-  bool _suppressAssignmentRefetch = false;
-  bool get suppressAssignmentRefetch => _suppressAssignmentRefetch;
+  SessionFailure? _failure;
+  DateTime? _updatedAt;
 
-  String get _baseUrl => apiBaseUrl(_storage);
-
-  // Fallback used before the school calendar has been fetched at least once.
-  static const _fallbackTotalWeeks = 25;
+  ScheduleService(this._storage, this._http, AuthService _, this._tpAuth) {
+    _tpAuth.addListener(_onBindingChanged);
+  }
 
   SemesterInfo? get semesterInfo => _semesterInfo;
   CourseTable? get courseTable => _courseTable;
   TermCalendar? get termCalendar => _termCalendar;
   DateTime? get termBegin => _termCalendar?.termBegin;
   String? get selectedSemesterId => _selectedSemesterId;
+  String? get owner => _owner;
   bool get loading => _loading;
-  String? get error => _error;
-
-  /// Teaching weeks in the selected semester, i.e. the upper bound for week
-  /// navigation. Falls back to a generous default until the calendar loads.
-  int get totalWeeks =>
-      (_termCalendar?.allTeachWeeks ?? 0) > 0
-          ? _termCalendar!.allTeachWeeks
-          : _fallbackTotalWeeks;
-
-  ScheduleService(this._storage, this._http, AuthService _, this._tpAuth);
+  String? get error => _failure?.message;
+  SessionFailure? get failure => _failure;
+  DateTime? get updatedAt => _updatedAt;
+  // EAMS initializes its course and exam pages in the same server session.
+  bool get suppressAssignmentRefetch => _loading;
+  int get totalWeeks => (_termCalendar?.allTeachWeeks ?? 0) > 0
+      ? _termCalendar!.allTeachWeeks
+      : 25;
 
   int currentWeek() {
     final begin = termBegin;
     if (begin == null) return 1;
-    final diff = DateTime.now().difference(begin).inDays;
-    if (diff < 0) return 1;
-    return ((diff ~/ 7) + 1).clamp(1, totalWeeks).toInt();
+    return ((DateTime.now().difference(begin).inDays ~/ 7) + 1)
+        .clamp(1, totalWeeks)
+        .toInt();
   }
 
-  /// Whether "today" actually falls within the selected semester — false
-  /// before the calendar has loaded, before the term begins, or after its
-  /// last teaching week. Callers should hide "this week"/"today" indicators
-  /// when this is false, since there is no meaningful "current week".
   bool get isTodayInTerm {
     final begin = termBegin;
     if (begin == null) return false;
-    final diff = DateTime.now().difference(begin).inDays;
-    if (diff < 0) return false;
-    final week = (diff ~/ 7) + 1;
-    return week <= totalWeeks;
+    final days = DateTime.now().difference(begin).inDays;
+    return days >= 0 && days ~/ 7 < totalWeeks;
   }
 
-  Map<String, String> _jsonHeaders() => {
-        'Content-Type': 'application/json; charset=UTF-8',
-      };
+  void _readCache() {
+    _semesterInfo =
+        _owner == null ? null : _storage.loadSemesters(owner: _owner);
+    _selectedSemesterId = _owner == null
+        ? null
+        : _storage.selectedSemesterFor(_owner!) ??
+            _semesterInfo?.defaultSemester;
+    _readSemesterCache();
+  }
 
-  /// Auth payload built from a [CookieProvider] snapshot captured at request
-  /// time. The epoch captured alongside is what makes the renew-retry
-  /// storm-safe (see [_postWithRetry]).
-  Map<String, dynamic> _authBody(CookieProvider cp) => {
-        // eams downstream cookie; studentId comes from the cpdaily binding.
-        'studentId': _tpAuth.cpdailyNode.account?.sid ?? '',
-        'cookies': cp.cookies,
-      };
+  void _readSemesterCache() {
+    final id = _selectedSemesterId;
+    _courseTable = _owner == null || id == null
+        ? null
+        : _storage.loadCourseTable(id, owner: _owner);
+    _termCalendar = _owner == null || id == null
+        ? null
+        : _storage.loadTermCalendar(id, owner: _owner);
+    _updatedAt = _owner == null || id == null
+        ? null
+        : _storage.scheduleUpdatedAt(_owner!, id);
+  }
 
-  bool get _hasCpdailyBinding => _tpAuth.cpdailyNode.isAvailable;
+  void _onBindingChanged() {
+    final node = _tpAuth.cpdailyNode;
+    if (_generation == node.generation) return;
+    _generation = node.generation;
+    _owner = node.identityKey;
+    _request++;
+    _loading = false;
+    _failure = null;
+    _readCache();
+    notifyListeners();
+    if (_ready && _owner != null) unawaited(fetchAll());
+  }
 
   Future<void> loadCachedData() async {
-    _semesterInfo = _storage.loadSemesters();
-    _selectedSemesterId =
-        _storage.selectedSemester ?? _semesterInfo?.defaultSemester;
-    if (_selectedSemesterId != null) {
-      _courseTable = _storage.loadCourseTable(_selectedSemesterId!);
-    }
-    _termCalendar = _storage.loadTermCalendar(_selectedSemesterId ?? '');
-    notifyListeners();
-  }
-
-  Future<void> fetchAll() async {
-    if (_loading) return; // 避免启动时并发重复调用
-    if (!_hasCpdailyBinding) return;
-    _loading = true;
-    _error = null;
-    notifyListeners();
-
-    try {
-      await fetchSemesters();
-      _selectedSemesterId ??= _semesterInfo?.defaultSemester;
-      if (_selectedSemesterId != null) {
-        await Future.wait([
-          fetchCourseTable(_selectedSemesterId!),
-          _fetchTermBeginForSemester(_selectedSemesterId!),
-        ]);
-      }
-    } catch (e) {
-      _error = e.toString();
-    } finally {
-      _loading = false;
-      notifyListeners();
-    }
-  }
-
-  Future<void> fetchSemesters() async {
-    final resp = await _postWithRetry(
-      '$_baseUrl/schedule/semesters',
-      const <String, dynamic>{},
-      'fetchSemesters',
-    );
-    final data = jsonDecode(resp.body) as Map<String, dynamic>;
-    if (data['success'] != true) {
-      throw Exception(data['error'] as String? ?? 'Failed to fetch semesters');
-    }
-
-    _semesterInfo = SemesterInfo.fromJson(data['data'] as Map<String, dynamic>);
-    await _storage.saveSemesters(_semesterInfo!);
-    notifyListeners();
-  }
-
-  Future<void> fetchCourseTable(String semesterId) async {
-    final extra = <String, dynamic>{
-      'semester_id': semesterId,
-      if (_semesterInfo?.tableId.isNotEmpty == true)
-        'table_id': _semesterInfo!.tableId,
-    };
-
-    final resp = await _postWithRetry(
-      '$_baseUrl/schedule/course_table',
-      extra,
-      'fetchCourseTable',
-    );
-    final data = jsonDecode(resp.body) as Map<String, dynamic>;
-    if (data['success'] != true) {
-      throw Exception(
-        data['error'] as String? ?? 'Failed to fetch course table',
-      );
-    }
-
-    _courseTable = CourseTable.fromApiResponse(
-      data['data'] as Map<String, dynamic>,
-    );
-    await _storage.saveCourseTable(semesterId, _courseTable!);
-    notifyListeners();
-  }
-
-  Future<void> _fetchTermBeginForSemester(String semesterId) async {
-    // Try to find the year and semester number from semesterInfo
-    if (_semesterInfo == null) return;
-
-    String? year;
-    String? semNum;
-    for (final yearEntry in _semesterInfo!.semesters.entries) {
-      for (final semEntry in yearEntry.value.entries) {
-        if (semEntry.value == semesterId) {
-          // yearEntry.key is like "2024-2025"
-          year = yearEntry.key.split('-').first;
-          // rank 0/1/2 (秋/春/暑) -> the term number the backend expects (1/2/3);
-          // unrecognized term keys fall back to spring (2).
-          final rank = semesterTermRank(semEntry.key);
-          semNum = rank < kSemesterTermNames.length
-              ? (rank + 1).toString()
-              : '2';
-          break;
-        }
-      }
-      if (year != null) break;
-    }
-
-    if (year == null || semNum == null) return;
-    await fetchTermBegin(year, semNum, semesterId);
-  }
-
-  Future<void> fetchTermBegin(
-    String year,
-    String semester,
-    String cacheKey,
-  ) async {
-    final extra = <String, dynamic>{'year': year, 'semester': semester};
-
-    final resp = await _postWithRetry(
-      '$_baseUrl/schedule/term_begin',
-      extra,
-      'fetchTermBegin',
-    );
-    final data = jsonDecode(resp.body) as Map<String, dynamic>;
-    if (data['success'] != true) {
-      throw Exception(data['error'] as String? ?? 'Failed to fetch term begin');
-    }
-
-    _termCalendar = TermCalendar.fromJson(data['data'] as Map<String, dynamic>);
-    await _storage.saveTermCalendar(cacheKey, _termCalendar!);
-    notifyListeners();
+    _onBindingChanged();
+    _ready = true;
   }
 
   Future<void> selectSemester(String semesterId) async {
-    // No-op if the semester is already selected.
-    if (_selectedSemesterId == semesterId) return;
+    if (_selectedSemesterId == semesterId || _owner == null) return;
+    _request++;
+    _loading = false;
     _selectedSemesterId = semesterId;
-    await _storage.setSelectedSemester(semesterId);
+    _readSemesterCache();
+    await _storage.setSelectedSemester(semesterId, owner: _owner);
+    await fetchAll();
+  }
 
-    // Load cached data for the new semester so the UI updates instantly.
-    _courseTable = _storage.loadCourseTable(semesterId);
-    _termCalendar = _storage.loadTermCalendar(semesterId);
-    // Notify the cached-swap UI update. AssignmentService._onScheduleChanged
-    // sees the semester changed and would fire fetchAssignments here — but
-    // that would race our own fetchCourseTable below (both hit
-    // courseTableForStd.action on the same EAMS session, and concurrent
-    // access to EAMS's stateful Spring/Struts session returns a partially
-    // initialized page → "Failed to extract numeric ids"). We suppress the
-    // assignment refetch during our own fetch and fire it once at the end.
-    _suppressAssignmentRefetch = true;
-    notifyListeners();
-
-    if (!_hasCpdailyBinding) {
-      _suppressAssignmentRefetch = false;
-      return;
-    }
-
+  Future<void> fetchAll() async {
+    if (_loading || _owner == null) return;
+    final owner = _owner!;
+    final request = ++_request;
     _loading = true;
-    _error = null;
+    _failure = null;
     notifyListeners();
-
     try {
-      await Future.wait([
-        fetchCourseTable(semesterId),
-        _fetchTermBeginForSemester(semesterId),
-      ]);
+      final semesters = SemesterInfo.fromJson(await _post('semesters', {}));
+      if (request != _request) return;
+      final id = _selectedSemesterId ?? semesters.defaultSemester;
+      if (id.isEmpty) throw SessionFailure.unavailable;
+      final tableData = await _post('course_table', {
+        'semester_id': id,
+        if (semesters.tableId.isNotEmpty) 'table_id': semesters.tableId,
+      });
+      if (tableData['courses'] is! List || tableData['periods'] is! List) {
+        throw SessionFailure.unavailable;
+      }
+      final table = CourseTable.fromApiResponse(tableData);
+      if (request != _request) return;
+      String? year;
+      String? term;
+      for (final entry in semesters.semesters.entries) {
+        for (final item in entry.value.entries) {
+          if (item.value == id) {
+            year = entry.key.split('-').first;
+            final rank = semesterTermRank(item.key);
+            term = rank < kSemesterTermNames.length ? '${rank + 1}' : '2';
+          }
+        }
+      }
+      if (year == null || term == null) throw SessionFailure.unavailable;
+      final calendar = TermCalendar.fromJson(
+        await _post('term_begin', {
+          'year': year,
+          'semester': term,
+        }),
+      );
+      if (request != _request) return;
+      final now = DateTime.now();
+      _semesterInfo = semesters;
+      _selectedSemesterId = id;
+      _courseTable = table;
+      _termCalendar = calendar;
+      _updatedAt = now;
+      await _storage.saveSemesters(semesters, owner: owner);
+      await _storage.setSelectedSemester(id, owner: owner);
+      await _storage.saveCourseTable(id, table, owner: owner);
+      await _storage.saveTermCalendar(id, calendar, owner: owner);
+      await _storage.saveScheduleUpdatedAt(owner, id, now);
     } catch (e) {
-      _error = e.toString();
+      if (request == _request) {
+        _failure = e is SessionFailure ? e : SessionFailure.unavailable;
+      }
     } finally {
-      _loading = false;
-      _suppressAssignmentRefetch = false;
-      // This final notify fires _onScheduleChanged again. Because
-      // _suppressAssignmentRefetch is now false, AssignmentService will
-      // refetch (the EAMS session is primed by our fetchCourseTable above,
-      // so exam_table succeeds on the first try).
-      notifyListeners();
+      if (request == _request) {
+        _loading = false;
+        notifyListeners();
+      }
     }
   }
 
-  /// POST [url] with CpDaily auth + [extra] body fields. On 401 the eams
-  /// node is renewed exactly once (single-flighted across all concurrent
- /// callers) and the request retried with the fresh cookie. For a stale
- /// parent tgc, [SessionTree.withCookie] falls back to renewing the
- /// cpdaily parent then re-minting the eams cookie. Throws on any non-200
- /// after the retry budget is exhausted.
-  Future<http.Response> _postWithRetry(
-    String url,
-    Map<String, dynamic> extra,
-    String tag,
-  ) async {
+  Future<Map<String, dynamic>> _post(
+      String path, Map<String, dynamic> extra,) async {
     final node = _tpAuth.eamsNode;
-    final resp = await _tpAuth.sessionTree.withCookie<http.Response>(
-      node,
-      (cp) async {
-        final body = {..._authBody(cp), ...extra};
-        final r = await _http.post(
-          Uri.parse(url),
-          headers: _jsonHeaders(),
-          body: jsonEncode(body),
-          tag: tag,
-        );
-        return CookieAction(
-          r,
-          expired: r.statusCode == 401,
-        );
-      },
-    );
-    if (resp == null) {
-      throw Exception('cpdaily session unavailable');
+    final generation = node.generation;
+    final response =
+        await _tpAuth.sessionTree.withCookie<http.Response>(node, (cp) async {
+      final r = await _http.post(
+        Uri.parse('${apiBaseUrl(_storage)}/schedule/$path'),
+        headers: {'Content-Type': 'application/json; charset=UTF-8'},
+        body: jsonEncode({..._authBody(cp), ...extra}),
+        tag: 'schedule:$path',
+      );
+      return CookieAction(r, expired: r.statusCode == 401);
+    });
+    if (generation != node.generation) throw SessionFailure.changed;
+    if (response == null) throw node.lastFailure ?? SessionFailure.unavailable;
+    if (response.statusCode != 200) {
+      throw SessionFailure.fromStatus(response.statusCode);
     }
-    if (resp.statusCode != 200) {
-      throw Exception('Request failed with status ${resp.statusCode}');
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    if (data['success'] != true || data['data'] is! Map) {
+      throw SessionFailure.unavailable;
     }
-    return resp;
+    return (data['data'] as Map).cast<String, dynamic>();
+  }
+
+  Map<String, dynamic> _authBody(CookieProvider cp) => {
+        'studentId': cp.studentId,
+        'cookies': cp.cookies,
+      };
+
+  @override
+  void dispose() {
+    _request++;
+    _tpAuth.removeListener(_onBindingChanged);
+    super.dispose();
   }
 }

--- a/lib/services/session/session_failure.dart
+++ b/lib/services/session/session_failure.dart
@@ -1,0 +1,34 @@
+enum SessionFailureKind { unbound, expired, forbidden, temporary, changed }
+
+class SessionFailure implements Exception {
+  const SessionFailure(this.kind, this.message);
+
+  final SessionFailureKind kind;
+  final String message;
+
+  bool get needsLogin =>
+      kind == SessionFailureKind.unbound || kind == SessionFailureKind.expired;
+
+  static const unavailable = SessionFailure(
+    SessionFailureKind.temporary,
+    '暂时无法连接校园服务，请稍后重试',
+  );
+  static const changed = SessionFailure(
+    SessionFailureKind.changed,
+    '校园账号已变更，请重新加载',
+  );
+
+  factory SessionFailure.fromStatus(int status) => switch (status) {
+        401 =>
+          const SessionFailure(SessionFailureKind.expired, '登录状态已失效，请重新登录'),
+        403 => const SessionFailure(SessionFailureKind.forbidden, '当前账号没有访问权限'),
+        429 =>
+          const SessionFailure(SessionFailureKind.temporary, '请求过于频繁，请稍后重试'),
+        504 =>
+          const SessionFailure(SessionFailureKind.temporary, '校园服务响应超时，请稍后重试'),
+        _ => unavailable,
+      };
+
+  @override
+  String toString() => message;
+}

--- a/lib/services/session/session_node.dart
+++ b/lib/services/session/session_node.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import '../../models/third_party_account.dart';
 import '../http_client.dart';
 import 'cookie_provider.dart';
+import 'session_failure.dart';
 
 /// Callback the facade ([ThirdPartyAuthService]) installs so a top-level
 /// node can persist a refreshed [ThirdPartyAccount] back into secure storage
@@ -125,9 +126,43 @@ class SessionNode extends ChangeNotifier {
 
   /// Set the bound account. Only meaningful for top-level nodes; calling on
   /// a non-top-level node is a no-op.
-  void setAccount(ThirdPartyAccount? acc) {
-    if (parent != null) return; // non-top-level: no account
+  String? get identityKey {
+    final acc = _account;
+    if (acc == null) return null;
+    final identity = (acc.sid?.isNotEmpty == true) ? acc.sid! : acc.account;
+    return '$id:${acc.raw['tenantId'] ?? ''}:$identity';
+  }
+
+  int _generation = 0;
+  int get generation => parent?.generation ?? _generation;
+  SessionFailure? lastFailure;
+  DateTime? verifiedAt;
+
+  void setAccount(ThirdPartyAccount? acc, {bool renewed = false}) {
+    if (parent != null) return;
+    final previous = _account;
+    final changed = previous?.token != acc?.token ||
+        previous?.sid != acc?.sid ||
+        previous?.account != acc?.account ||
+        previous?.raw['tgc'] != acc?.raw['tgc'] ||
+        previous?.raw['tenantId'] != acc?.raw['tenantId'] ||
+        previous?.raw['sessionToken'] != acc?.raw['sessionToken'];
     _account = acc;
+    if (changed && !renewed) {
+      _generation++;
+      _renewInFlight = null;
+      markRenewed();
+    }
+    if (changed) {
+      lastFailure = null;
+      verifiedAt = null;
+    }
+    notifyListeners();
+  }
+
+  void markVerified() {
+    lastFailure = null;
+    verifiedAt = DateTime.now();
     notifyListeners();
   }
 
@@ -172,7 +207,11 @@ class SessionNode extends ChangeNotifier {
     // Non-top-level: derived cookie
     final c = _derivedCookie;
     if (c == null || c.isEmpty) return null;
-    return CookieProvider(cookies: c, domain: _domain);
+    return CookieProvider(
+      cookies: c,
+      domain: _domain,
+      studentId: parent?.account?.sid ?? '',
+    );
   }
 
   /// Top-level credential extraction: cpdaily concatenates CASTGC onto the
@@ -211,14 +250,8 @@ class SessionNode extends ChangeNotifier {
   int _epoch = 0;
   Future<bool>? _renewInFlight;
 
-  /// Whether the last [doRenew] failure was a credential-level error
-  /// (HTTP 401 from the renew endpoint), as opposed to a server error (500)
-  /// or network issue. [SessionTree.withCookie] uses this to decide whether
-  /// the two-level parent-renew fallback is worth attempting: a 500 from the
-  /// downstream endpoint won't be fixed by re-minting the parent tgc, so we
-  /// skip the escalation entirely.
-  bool _lastRenewWasCredentialError = false;
-  bool get lastRenewWasCredentialError => _lastRenewWasCredentialError;
+  bool get lastRenewWasCredentialError =>
+      lastFailure?.kind == SessionFailureKind.expired;
 
   /// Current epoch. Bumped after every successful [renew]. Callers capture
   /// this when reading cookies and pass it to [renewIfNeeded].
@@ -249,6 +282,8 @@ class SessionNode extends ChangeNotifier {
   void onParentRenewed() {
     if (parent != null) {
       _derivedCookie = null;
+      _epoch++;
+      verifiedAt = null;
       // Clear persisted cookie too — it was minted from the old parent tgc
       // and is now invalid. The next withCookie call will re-mint.
       final pd = persistDerived;
@@ -278,7 +313,12 @@ class SessionNode extends ChangeNotifier {
   /// CpDaily keep-alive: POST /auth/renew with stored session fields.
   Future<bool> _renewCpdailySession() async {
     final acc = _account;
-    if (acc == null) return false;
+    if (acc == null) {
+      lastFailure =
+          const SessionFailure(SessionFailureKind.unbound, '请先绑定校园账号');
+      return false;
+    }
+    final version = generation;
     try {
       final resp = await http.post(
         Uri.parse('${baseUrl()}${renewPath ?? '/auth/renew'}'),
@@ -286,23 +326,30 @@ class SessionNode extends ChangeNotifier {
         body: jsonEncode({
           'sessionToken': acc.raw['sessionToken'] ?? '',
           'tgc': acc.raw['tgc'] ?? '',
-          'userId': acc.raw['userId'] ?? '',
+          'userId': acc.raw['userId'] ?? acc.sid ?? '',
           'tenantId': acc.raw['tenantId'] ?? '',
         }),
         tag: 'cpdailyRenew',
       );
-      if (resp.statusCode != 200) return false;
+      if (generation != version) return false;
+      if (resp.statusCode != 200) {
+        lastFailure = SessionFailure.fromStatus(resp.statusCode);
+        return false;
+      }
       final data = jsonDecode(resp.body) as Map<String, dynamic>;
-      if (data['success'] != true) return false;
+      if (data['success'] != true) {
+        lastFailure = SessionFailure.unavailable;
+        return false;
+      }
 
       final newRaw = {
         ...acc.raw,
         'sessionToken':
             data['sessionToken'] as String? ?? acc.raw['sessionToken'] ?? '',
         'tgc': data['tgc'] as String? ?? acc.raw['tgc'] ?? '',
-        'userId': data['userId'] as String? ?? acc.raw['userId'] ?? '',
-        'tenantId':
-            data['tenantId'] as String? ?? acc.raw['tenantId'] ?? '',
+        'userId':
+            data['userId'] as String? ?? acc.raw['userId'] ?? acc.sid ?? '',
+        'tenantId': data['tenantId'] as String? ?? acc.raw['tenantId'] ?? '',
         'cookies': data['cookies'] as String? ?? acc.raw['cookies'] ?? '',
       };
       final updated = ThirdPartyAccount(
@@ -322,9 +369,12 @@ class SessionNode extends ChangeNotifier {
       );
       _account = updated;
       await persist(updated);
+      if (generation != version) return false;
+      lastFailure = null;
       markRenewed();
       return true;
     } catch (_) {
+      if (generation == version) lastFailure = SessionFailure.unavailable;
       return false;
     }
   }
@@ -333,9 +383,17 @@ class SessionNode extends ChangeNotifier {
   /// account+password, receive a fresh token.
   Future<bool> _renewWithPassword() async {
     final acc = _account;
-    if (acc == null || !acc.autoRenew) return false;
+    if (acc == null || !acc.autoRenew) {
+      lastFailure =
+          const SessionFailure(SessionFailureKind.expired, '登录状态已失效，请重新登录');
+      return false;
+    }
+    final version = generation;
     final pw = acc.password;
-    if (pw == null || pw.isEmpty) return false;
+    if (pw == null || pw.isEmpty) {
+      lastFailure = SessionFailure.fromStatus(401);
+      return false;
+    }
     try {
       final body = <String, dynamic>{
         'account': acc.account,
@@ -352,9 +410,16 @@ class SessionNode extends ChangeNotifier {
         body: jsonEncode(body),
         tag: 'thirdPartyRenew:$id',
       );
-      if (resp.statusCode != 200) return false;
+      if (generation != version) return false;
+      if (resp.statusCode != 200) {
+        lastFailure = SessionFailure.fromStatus(resp.statusCode);
+        return false;
+      }
       final data = jsonDecode(resp.body) as Map<String, dynamic>;
-      if (data['success'] != true) return false;
+      if (data['success'] != true) {
+        lastFailure = SessionFailure.unavailable;
+        return false;
+      }
       final d = (data['data'] as Map?)?.cast<String, dynamic>() ?? const {};
       final token = d['token'] as String?;
       if (token == null || token.isEmpty) return false;
@@ -375,9 +440,12 @@ class SessionNode extends ChangeNotifier {
       );
       _account = renewed;
       await persist(renewed);
+      if (generation != version) return false;
+      lastFailure = null;
       markRenewed();
       return true;
     } catch (_) {
+      if (generation == version) lastFailure = SessionFailure.unavailable;
       return false;
     }
   }
@@ -385,9 +453,11 @@ class SessionNode extends ChangeNotifier {
   /// Downstream cookie minting (eams, elearning): POST the parent's tgc,
   /// receive a downstream cookie string.
   Future<bool> _renewWithParentCookie() async {
+    final version = generation;
+    final parentEpoch = parent?.epoch;
     final tgc = parent?.rawFields['tgc'] as String? ?? '';
     if (tgc.isEmpty) {
-      _lastRenewWasCredentialError = true;
+      lastFailure = SessionFailure.fromStatus(401);
       return false;
     }
     try {
@@ -400,13 +470,20 @@ class SessionNode extends ChangeNotifier {
       // 401 → parent tgc is stale/invalid → credential error (worth
       // escalating to parent renew). 5xx → server/transient failure →
       // NOT a credential error (escalation won't help).
-      _lastRenewWasCredentialError = resp.statusCode == 401;
-      if (resp.statusCode != 200) return false;
+      if (generation != version || parent?.epoch != parentEpoch) return false;
+      if (resp.statusCode != 200) {
+        lastFailure = SessionFailure.fromStatus(resp.statusCode);
+        return false;
+      }
       final data = jsonDecode(resp.body) as Map<String, dynamic>;
-      if (data['success'] != true) return false;
+      if (data['success'] != true) {
+        lastFailure = SessionFailure.unavailable;
+        return false;
+      }
       final d = (data['data'] as Map?)?.cast<String, dynamic>() ?? const {};
       final cookie = d['token'] as String?;
       if (cookie == null || cookie.isEmpty) return false;
+      lastFailure = null;
       _derivedCookie = cookie;
       // Persist so cold start can skip the SSO bounce.
       final pd = persistDerived;
@@ -419,7 +496,7 @@ class SessionNode extends ChangeNotifier {
       notifyListeners();
       return true;
     } catch (_) {
-      _lastRenewWasCredentialError = false;
+      if (generation == version) lastFailure = SessionFailure.unavailable;
       return false;
     }
   }
@@ -428,7 +505,10 @@ class SessionNode extends ChangeNotifier {
   /// share one in-flight renew and observe the same result.
   Future<bool> renew() {
     if (_renewInFlight != null) return _renewInFlight!;
-    final f = doRenew().whenComplete(() => _renewInFlight = null);
+    late final Future<bool> f;
+    f = doRenew().whenComplete(() {
+      if (identical(_renewInFlight, f)) _renewInFlight = null;
+    });
     _renewInFlight = f;
     return f;
   }

--- a/lib/services/session/session_tree.dart
+++ b/lib/services/session/session_tree.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import '../../models/third_party_account.dart';
 import '../http_client.dart';
 import 'cookie_provider.dart';
+import 'session_failure.dart';
 import 'session_node.dart';
 
 /// The unified session tree.
@@ -114,8 +115,9 @@ class SessionTree extends ChangeNotifier {
   /// Feed an account mutation from the facade into the matching top-level
   /// node. Used by bind/unbind/replaceAll/updateRaw. Child nodes ignore
   /// this (they carry no account).
-  void setAccount(ThirdPartyPlatform p, ThirdPartyAccount? acc) {
-    nodeFor(p).setAccount(acc);
+  void setAccount(ThirdPartyPlatform p, ThirdPartyAccount? acc,
+      {bool renewed = false,}) {
+    nodeFor(p).setAccount(acc, renewed: renewed);
   }
 
   /// Hydrate a child node's derived cookie from persistent storage at boot.
@@ -160,7 +162,10 @@ class SessionTree extends ChangeNotifier {
     Future<CookieAction<T>> Function(CookieProvider provider) action,
   ) async {
     // First level: single-node renew-retry (handles initial minting + 401).
+    final generation = node.generation;
+    final parentEpoch = node.parent?.epoch;
     var result = await _renewRetry(node, action);
+    if (node.generation != generation) return null;
     if (result != null) return result;
 
     // Second level: for child nodes whose first-level retry returned null.
@@ -171,13 +176,19 @@ class SessionTree extends ChangeNotifier {
     // This prevents wasteful /auth/renew calls on transient backend errors.
     if (node.parent == null) return null;
     if (!node.lastRenewWasCredentialError) return null;
-    final parentOk = await node.parent!.renewIfNeeded(node.parent!.epoch);
-    if (!parentOk) return null;
+    final parentOk = await node.parent!.renewIfNeeded(parentEpoch!);
+    if (node.generation != generation) return null;
+    if (!parentOk) {
+      node.lastFailure = node.parent!.lastFailure;
+      return null;
+    }
     final childOk = await node.renew();
-    if (!childOk) return null;
+    if (!childOk || node.generation != generation) return null;
     final cp = node.cookieProvider;
     if (cp == null) return null;
     final retried = await action(cp);
+    if (node.generation != generation) return null;
+    if (retried.expired) node.lastFailure = SessionFailure.fromStatus(401);
     return retried.value;
   }
 
@@ -189,26 +200,30 @@ class SessionTree extends ChangeNotifier {
     SessionNode node,
     Future<CookieAction<T>> Function(CookieProvider provider) action,
   ) async {
+    final generation = node.generation;
     // If not available, try to mint credentials first (initial minting for
     // child nodes, or a no-op for top-level nodes that are already bound).
     if (!node.isAvailable) {
       final ok = await node.renew();
-      if (!ok) return null;
+      if (!ok || node.generation != generation) return null;
     }
     var cp = node.cookieProvider;
     if (cp == null) return null;
 
+    final beforeEpoch = node.epoch;
     var result = await action(cp);
+    if (node.generation != generation) return null;
     if (!result.expired) return result.value;
 
     // 401: renew if the cookie hasn't already been refreshed since we read it.
-    final beforeEpoch = node.epoch;
     final ok = await node.renewIfNeeded(beforeEpoch);
-    if (!ok) return null;
+    if (!ok || node.generation != generation) return null;
 
     cp = node.cookieProvider;
     if (cp == null) return null;
     final retried = await action(cp);
+    if (node.generation != generation) return null;
+    if (retried.expired) node.lastFailure = SessionFailure.fromStatus(401);
     return retried.value;
   }
 

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -23,7 +23,6 @@ class StorageService {
   static const _syncMasterKeyKey = 'sync_master_key'; // secure storage
   static const _deviceIdKey = 'device_id';
 
-
   final FlutterSecureStorage _secure;
   final SharedPreferences _prefs;
 
@@ -34,7 +33,8 @@ class StorageService {
 
   // Secure session storage
   Future<void> saveSession(UserSession session) async {
-    await _secure.write(key: _sessionKey, value: jsonEncode(session.toJson()));
+    await _writeCredential(() =>
+        _secure.write(key: _sessionKey, value: jsonEncode(session.toJson())),);
   }
 
   Future<UserSession?> loadSession() async {
@@ -44,7 +44,15 @@ class StorageService {
   }
 
   Future<void> clearSession() async {
-    await _secure.delete(key: _sessionKey);
+    await _writeCredential(() => _secure.delete(key: _sessionKey));
+  }
+
+  Future<void> _credentialWrites = Future.value();
+
+  Future<void> _writeCredential(Future<void> Function() action) {
+    final pending = _credentialWrites.then((_) => action());
+    _credentialWrites = pending.catchError((Object _) {});
+    return pending;
   }
 
   // Secure third-party account storage (one secure key per platform)
@@ -52,9 +60,11 @@ class StorageService {
   String _thirdPartyKey(ThirdPartyPlatform p) => '$_thirdPartyKeyPrefix${p.id}';
 
   Future<void> saveThirdPartyAccount(ThirdPartyAccount acc) async {
-    await _secure.write(
-      key: _thirdPartyKey(acc.platform),
-      value: jsonEncode(acc.toJson()),
+    await _writeCredential(
+      () => _secure.write(
+        key: _thirdPartyKey(acc.platform),
+        value: jsonEncode(acc.toJson()),
+      ),
     );
   }
 
@@ -99,12 +109,12 @@ class StorageService {
   }
 
   Future<void> clearThirdPartyAccount(ThirdPartyPlatform p) async {
-    await _secure.delete(key: _thirdPartyKey(p));
+    await _writeCredential(() => _secure.delete(key: _thirdPartyKey(p)));
   }
 
   Future<void> clearAllThirdPartyAccounts() async {
     for (final p in ThirdPartyPlatform.values) {
-      await _secure.delete(key: _thirdPartyKey(p));
+      await _writeCredential(() => _secure.delete(key: _thirdPartyKey(p)));
     }
   }
 
@@ -113,9 +123,11 @@ class StorageService {
   static const _derivedCookieKeyPrefix = 'derived_cookie_';
 
   Future<void> saveDerivedCookie(String nodeId, String cookie) async {
-    await _secure.write(
-      key: '$_derivedCookieKeyPrefix$nodeId',
-      value: cookie,
+    await _writeCredential(
+      () => _secure.write(
+        key: '$_derivedCookieKeyPrefix$nodeId',
+        value: cookie,
+      ),
     );
   }
 
@@ -124,12 +136,14 @@ class StorageService {
   }
 
   Future<void> clearDerivedCookie(String nodeId) async {
-    await _secure.delete(key: '$_derivedCookieKeyPrefix$nodeId');
+    await _writeCredential(
+        () => _secure.delete(key: '$_derivedCookieKeyPrefix$nodeId'),);
   }
 
   Future<void> clearAllDerivedCookies() async {
     for (final id in const ['eams', 'elearning']) {
-      await _secure.delete(key: '$_derivedCookieKeyPrefix$id');
+      await _writeCredential(
+          () => _secure.delete(key: '$_derivedCookieKeyPrefix$id'),);
     }
   }
 
@@ -194,29 +208,37 @@ class StorageService {
   static const _termBeginPrefix = 'schedule_term_begin_';
   static const _selectedSemesterKey = 'schedule_selected_semester';
 
-  Future<void> saveSemesters(SemesterInfo info) =>
-      _prefs.setString(_semestersKey, jsonEncode(info.toJson()));
+  String _ownedKey(String key, String? owner) =>
+      owner == null ? key : '$key:$owner';
 
-  SemesterInfo? loadSemesters() {
-    final raw = _prefs.getString(_semestersKey);
+  Future<void> saveSemesters(SemesterInfo info, {String? owner}) => _prefs
+      .setString(_ownedKey(_semestersKey, owner), jsonEncode(info.toJson()));
+
+  SemesterInfo? loadSemesters({String? owner}) {
+    final raw = _prefs.getString(_ownedKey(_semestersKey, owner));
     if (raw == null) return null;
     return SemesterInfo.fromJson(jsonDecode(raw) as Map<String, dynamic>);
   }
 
-  Future<void> saveCourseTable(String semesterId, CourseTable table) => _prefs
-      .setString('$_courseTablePrefix$semesterId', jsonEncode(table.toJson()));
+  Future<void> saveCourseTable(String semesterId, CourseTable table,
+          {String? owner,}) =>
+      _prefs.setString(_ownedKey('$_courseTablePrefix$semesterId', owner),
+          jsonEncode(table.toJson()),);
 
-  CourseTable? loadCourseTable(String semesterId) {
-    final raw = _prefs.getString('$_courseTablePrefix$semesterId');
+  CourseTable? loadCourseTable(String semesterId, {String? owner}) {
+    final raw =
+        _prefs.getString(_ownedKey('$_courseTablePrefix$semesterId', owner));
     if (raw == null) return null;
     return CourseTable.fromJson(jsonDecode(raw) as Map<String, dynamic>);
   }
 
-  Future<void> saveTermCalendar(String key, TermCalendar info) => _prefs
-      .setString('$_termBeginPrefix$key', jsonEncode(info.toJson()));
+  Future<void> saveTermCalendar(String key, TermCalendar info,
+          {String? owner,}) =>
+      _prefs.setString(
+          _ownedKey('$_termBeginPrefix$key', owner), jsonEncode(info.toJson()),);
 
-  TermCalendar? loadTermCalendar(String key) {
-    final raw = _prefs.getString('$_termBeginPrefix$key');
+  TermCalendar? loadTermCalendar(String key, {String? owner}) {
+    final raw = _prefs.getString(_ownedKey('$_termBeginPrefix$key', owner));
     if (raw == null) return null;
     try {
       return TermCalendar.fromJson(jsonDecode(raw) as Map<String, dynamic>);
@@ -226,17 +248,30 @@ class StorageService {
   }
 
   String? get selectedSemester => _prefs.getString(_selectedSemesterKey);
-  Future<void> setSelectedSemester(String id) =>
-      _prefs.setString(_selectedSemesterKey, id);
+  String? selectedSemesterFor(String owner) =>
+      _prefs.getString(_ownedKey(_selectedSemesterKey, owner));
+  Future<void> setSelectedSemester(String id, {String? owner}) =>
+      _prefs.setString(_ownedKey(_selectedSemesterKey, owner), id);
+
+  DateTime? scheduleUpdatedAt(String owner, String semester) {
+    final value = _prefs.getString('schedule_updated:$owner:$semester');
+    return value == null ? null : DateTime.tryParse(value);
+  }
+
+  Future<void> saveScheduleUpdatedAt(
+          String owner, String semester, DateTime at,) =>
+      _prefs.setString(
+          'schedule_updated:$owner:$semester', at.toIso8601String(),);
 
   // Assignments cache (non-sensitive — stored as JSON in SharedPreferences)
   static const _assignmentsKey = 'cached_assignments';
 
-  Future<void> saveCachedAssignments(List<Map<String, dynamic>> items) =>
-      _prefs.setString(_assignmentsKey, jsonEncode(items));
+  Future<void> saveCachedAssignments(List<Map<String, dynamic>> items,
+          {String? owner,}) =>
+      _prefs.setString(_ownedKey(_assignmentsKey, owner), jsonEncode(items));
 
-  List<Map<String, dynamic>> loadCachedAssignments() {
-    final raw = _prefs.getString(_assignmentsKey);
+  List<Map<String, dynamic>> loadCachedAssignments({String? owner}) {
+    final raw = _prefs.getString(_ownedKey(_assignmentsKey, owner));
     if (raw == null) return const [];
     try {
       final list = jsonDecode(raw) as List<dynamic>;
@@ -246,16 +281,19 @@ class StorageService {
     }
   }
 
-  Future<void> clearCachedAssignments() => _prefs.remove(_assignmentsKey);
+  Future<void> clearCachedAssignments({String? owner}) =>
+      _prefs.remove(_ownedKey(_assignmentsKey, owner));
 
   // Local user overrides on assignments (completion flips + hidden ids).
   static const _assignmentOverridesKey = 'assignment_overrides';
 
-  Future<void> saveAssignmentOverrides(AssignmentOverrides ov) =>
-      _prefs.setString(_assignmentOverridesKey, jsonEncode(ov.toJson()));
+  Future<void> saveAssignmentOverrides(AssignmentOverrides ov,
+          {String? owner,}) =>
+      _prefs.setString(
+          _ownedKey(_assignmentOverridesKey, owner), jsonEncode(ov.toJson()),);
 
-  AssignmentOverrides loadAssignmentOverrides() {
-    final raw = _prefs.getString(_assignmentOverridesKey);
+  AssignmentOverrides loadAssignmentOverrides({String? owner}) {
+    final raw = _prefs.getString(_ownedKey(_assignmentOverridesKey, owner));
     if (raw == null) return AssignmentOverrides();
     try {
       return AssignmentOverrides.fromJson(

--- a/lib/services/third_party_auth_service.dart
+++ b/lib/services/third_party_auth_service.dart
@@ -26,12 +26,19 @@ class ThirdPartyAuthService extends ChangeNotifier {
   bool _suppressSyncPush = false;
   // SMS context for cpdaily binding flow (set by sendCpdailySmsCode).
   Map<String, dynamic>? _cpdailySmsContext;
+  String? _cpdailySmsPhone;
+  int _smsAttempt = 0;
+
+  void cancelCpdailySms() {
+    _smsAttempt++;
+    _cpdailySmsContext = null;
+    _cpdailySmsPhone = null;
+  }
 
   late final SessionTree _tree;
   // Stable per-device id, loaded in [initialize]. Stamped onto every locally
   // mutated account so the cloud-sync LWW merge converges.
   String _deviceId = '';
-
 
   ThirdPartyAuthService(this._storage, this._http) {
     _tree = SessionTree(
@@ -95,6 +102,7 @@ class ThirdPartyAuthService extends ChangeNotifier {
   /// wants the push to bypass the throttle so a removal is immediately
   /// reflected in the cloud blob.
   Future<void> Function({bool force})? onBindingsChanged;
+
   /// Hook fired when a platform is deliberately unbound. Wired by
   /// [SyncService] to record a tombstone so the deletion survives the next
   /// LWW merge (instead of being resurrected by an older remote copy).
@@ -123,17 +131,22 @@ class ThirdPartyAuthService extends ChangeNotifier {
   Future<void> _persistAccount(ThirdPartyAccount updated) async {
     // Stamp the renewed/refreshed account with this device's id + a fresh
     // updatedAt so the cloud-sync LWW merge treats it as the newest version.
+    final node = _tree.nodeFor(updated.platform);
+    if (!identical(node.account, updated)) return;
+    final version = node.generation;
     final touched = _touch(updated);
     await _storage.saveThirdPartyAccount(touched);
+    if (node.generation != version) return;
     // Re-sync the node's in-memory copy so UI + cookieProvider see the
     // stamped version. setAccount notifies; _onTreeChanged funnels it.
-    _tree.setAccount(touched.platform, touched);
+    _tree.setAccount(touched.platform, touched, renewed: true);
   }
 
   /// Persist/clear a child node's derived cookie. Installed as the tree's
   /// [PersistDerivedCookie] callback so eams/elearning cookie minting and
   /// parent-renew cascades flow through storage.
   Future<void> _persistDerivedCookie(String nodeId, String? cookie) async {
+    if (!_initialized) return;
     if (cookie == null) {
       await _storage.clearDerivedCookie(nodeId);
     } else {
@@ -195,6 +208,29 @@ class ThirdPartyAuthService extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<ThirdPartyAccount> _storeBinding(
+      ThirdPartyAccount account, int version,) async {
+    final node = _tree.nodeFor(account.platform);
+    if (node.generation != version) {
+      throw ThirdPartyBindException(account.platform, '账号已变更，请重新登录');
+    }
+    final previous = node.account;
+    final touched = _touch(account);
+    _tree.setAccount(account.platform, touched);
+    try {
+      await _storage.saveThirdPartyAccount(touched);
+    } catch (_) {
+      if (identical(node.account, touched)) {
+        _tree.setAccount(account.platform, previous);
+      }
+      rethrow;
+    }
+    if (!identical(node.account, touched)) {
+      throw ThirdPartyBindException(account.platform, '账号已变更，请重新登录');
+    }
+    return touched;
+  }
+
   Future<ThirdPartyAccount> bind({
     required ThirdPartyPlatform platform,
     required String account,
@@ -203,6 +239,7 @@ class ThirdPartyAuthService extends ChangeNotifier {
     List<String>? hydroDomains,
     bool autoRenew = false,
   }) async {
+    final version = _tree.nodeFor(platform).generation;
     final body = <String, dynamic>{
       'account': account,
       'password': password,
@@ -265,14 +302,12 @@ class ThirdPartyAuthService extends ChangeNotifier {
       password: autoRenew ? password : null,
     );
 
-    final touched = _touch(acc);
-    await _storage.saveThirdPartyAccount(touched);
-    _tree.setAccount(platform, touched);
-    return touched;
+    return _storeBinding(acc, version);
   }
 
   Future<void> unbind(ThirdPartyPlatform platform) async {
     _tree.setAccount(platform, null);
+    if (platform == ThirdPartyPlatform.cpdaily) cancelCpdailySms();
     await _storage.clearThirdPartyAccount(platform);
     // Unbinding cpdaily invalidates all downstream derived cookies.
     if (platform == ThirdPartyPlatform.cpdaily) {
@@ -341,8 +376,8 @@ class ThirdPartyAuthService extends ChangeNotifier {
         if (next != null && cur != null && _accountEqual(cur, next)) continue;
         if (next == null && cur == null) continue;
         if (next != null) {
-          await _storage.saveThirdPartyAccount(next);
           _tree.setAccount(p, next);
+          await _storage.saveThirdPartyAccount(next);
         } else {
           // Clearing cpdaily invalidates downstream derived cookies.
           if (p == ThirdPartyPlatform.cpdaily && cur != null) {
@@ -379,8 +414,8 @@ class ThirdPartyAuthService extends ChangeNotifier {
     final acc = _nodeAccount(platform);
     if (acc == null) return;
     final touched = _touch(acc.copyWith(raw: newRaw));
-    await _storage.saveThirdPartyAccount(touched);
     _tree.setAccount(platform, touched);
+    await _storage.saveThirdPartyAccount(touched);
   }
 
   // -- CpDaily SMS binding flow --
@@ -388,6 +423,8 @@ class ThirdPartyAuthService extends ChangeNotifier {
   /// Step 1: Send an SMS verification code for cpdaily binding.
   /// Reuses the existing /api/auth/mobile/send-sms endpoint.
   Future<void> sendCpdailySmsCode(String phone) async {
+    cancelCpdailySms();
+    final attempt = _smsAttempt;
     final resp = await _http.post(
       Uri.parse('$_baseUrl/auth/mobile/send-sms'),
       headers: {'Content-Type': 'application/json; charset=UTF-8'},
@@ -403,6 +440,8 @@ class ThirdPartyAuthService extends ChangeNotifier {
       );
     }
 
+    if (attempt != _smsAttempt) return;
+    _cpdailySmsPhone = phone;
     _cpdailySmsContext = data['context'] as Map<String, dynamic>?;
   }
 
@@ -412,10 +451,12 @@ class ThirdPartyAuthService extends ChangeNotifier {
     required String code,
     bool autoRenew = false,
   }) async {
-    if (_cpdailySmsContext == null) {
+    final version = _tree.cpdaily.generation;
+    final attempt = _smsAttempt;
+    if (_cpdailySmsContext == null || _cpdailySmsPhone != phone) {
       throw ThirdPartyBindException(
         ThirdPartyPlatform.cpdaily,
-        'Send SMS code first',
+        '请先为当前手机号发送验证码',
       );
     }
 
@@ -470,11 +511,13 @@ class ThirdPartyAuthService extends ChangeNotifier {
       autoRenew: false, // SMS binding does not support auto-renew
     );
 
-    final touched = _touch(acc);
-    await _storage.saveThirdPartyAccount(touched);
-    _tree.setAccount(ThirdPartyPlatform.cpdaily, touched);
-    _cpdailySmsContext = null;
-    return touched;
+    if (attempt != _smsAttempt) {
+      throw ThirdPartyBindException(
+          ThirdPartyPlatform.cpdaily, '登录已取消，请重新发送验证码',);
+    }
+    final saved = await _storeBinding(acc, version);
+    cancelCpdailySms();
+    return saved;
   }
 
   /// Boot-time best-effort renewal: for each bound account whose token is

--- a/test/assignment_service_test.dart
+++ b/test/assignment_service_test.dart
@@ -35,7 +35,14 @@ void main() {
       platform: 'gradescope',
       due: DateTime.utc(2026, 1, 20),
     );
-    await storage.saveCachedAssignments([oldBlackboard, oldGradescope]);
+    await storage.saveCachedAssignments(
+      [oldBlackboard],
+      owner: 'cpdaily:tenant:student:blackboard',
+    );
+    await storage.saveCachedAssignments(
+      [oldGradescope],
+      owner: 'gradescope::gradescope@example.com',
+    );
     // Primary account is the SSO identity session — no CASTGC on it.
     await storage.saveSession(
       UserSession(
@@ -125,10 +132,16 @@ void main() {
       service.assignments.map((a) => a.id),
       isNot(contains('blackboard-old')),
     );
-    expect(service.platformErrors['gradescope'], 'upstream failed');
+    expect(service.platformErrors['gradescope'], isNotNull);
 
-    final cachedIds =
-        storage.loadCachedAssignments().map((a) => a['id']).toList();
+    final cachedIds = [
+      ...storage.loadCachedAssignments(
+        owner: 'cpdaily:tenant:student:blackboard',
+      ),
+      ...storage.loadCachedAssignments(
+        owner: 'gradescope::gradescope@example.com',
+      ),
+    ].map((a) => a['id']).toList();
     expect(cachedIds, containsAll(['blackboard-new', 'gradescope-old']));
     expect(cachedIds, isNot(contains('blackboard-old')));
   });
@@ -138,7 +151,7 @@ void main() {
     FlutterSecureStorage.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
     final storage = StorageService(prefs);
-    await storage.setSelectedSemester('263');
+    await storage.setSelectedSemester('263', owner: 'cpdaily:tenant:student');
     await storage.saveSession(
       UserSession(
         userId: 'user',
@@ -259,7 +272,12 @@ void main() {
         }),
       ),
     );
-    expect(storage.loadCachedAssignments().single['kind'], 'exam');
+    expect(
+      storage.loadCachedAssignments(
+        owner: 'cpdaily:tenant:student:exam:263',
+      ).single['kind'],
+      'exam',
+    );
   });
 }
 


### PR DESCRIPTION
校园会话失效时有限续期，真正过期后提供重新登录；短信绑定默认走验证码，并丢弃解绑或切换账号后的迟到响应。课表、DDL 和考试缓存按校园账号与学期隔离，临时失败保留当前账号的上次成功数据；OA 提交失败不自动重放。

配套后端：HeZeBang/shanghaitech-cpdaily-auth#10。

验证：独立 Flutter analyze、iOS 模拟器构建通过；本地组合 74 项测试通过；现有 DDL 测试已适配账号缓存归属。真实校园业务接口尚未全部实测。
