### PR TITLE
修复校园网页退出与会话复用，开放 macOS 课程录播

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -87,6 +87,7 @@ Future<void> _realMain(SharedPreferences prefs) async {
     await assignmentService.clearCache();
     await assignmentService.clearAllOverrides();
     oaGymService.clearSession();
+    await thirdPartyAuthService.campusWebSession.prepare();
   };
 
   // Cloud-sync push hook: after any binding mutation, best-effort push the new
@@ -114,6 +115,7 @@ Future<void> _realMain(SharedPreferences prefs) async {
   // Hydrate everything from caches so the first frame paints with data.
   await authService.loadSession();
   await thirdPartyAuthService.initialize();
+  thirdPartyAuthService.campusWebSession.attachAuth(authService);
   await syncService.loadCachedKey();
   assignmentService.loadCached();
   await scheduleService.loadCachedData();

--- a/lib/pages/elrc_player_page.dart
+++ b/lib/pages/elrc_player_page.dart
@@ -160,16 +160,19 @@ JSON.stringify((() => {
       return;
     }
 
+    final isWebKit = defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.macOS;
+
     // WKWebView reports direct video documents as WebKit error 204 when AVKit
     // takes over playback. The video is usable; this callback is its success path.
-    if (defaultTargetPlatform == TargetPlatform.iOS && failure.errorCode == 204) {
+    if (isWebKit && failure.errorCode == 204) {
       _mediaReady(_loadGeneration, 'native player accepted the media document');
       return;
     }
 
     // Replacing a media document can cancel the retired navigation.
     if (failure.errorCode == -999 ||
-        (defaultTargetPlatform == TargetPlatform.iOS && failure.errorCode == 102)) {
+        (isWebKit && failure.errorCode == 102)) {
       _trace('ignored retired media navigation');
       return;
     }

--- a/lib/pages/elrc_recordings_page.dart
+++ b/lib/pages/elrc_recordings_page.dart
@@ -52,7 +52,8 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
   bool get _supported =>
       !kIsWeb &&
       (defaultTargetPlatform == TargetPlatform.iOS ||
-          defaultTargetPlatform == TargetPlatform.android);
+          defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.macOS);
 
   @override
   void didChangeDependencies() {
@@ -559,7 +560,7 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
 
   Widget _content() {
     if (!_supported) {
-      return const Center(child: Text('请在 iPhone 或 Android 手机中观看录播'));
+      return const Center(child: Text('当前平台暂不支持课程录播'));
     }
     if (_error != null && _courses == null && !_webVisible) {
       return _message(_error!, _retryCourses);
@@ -692,12 +693,23 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
           body: SafeArea(
             child: Stack(
               children: [
-                Positioned.fill(child: _content()),
+                // macOS suspends an Offstage WKWebView before asynchronous
+                // fetches finish. Keep it attached beneath the native content.
                 if (_controller != null)
                   Positioned.fill(
-                    child: Offstage(
-                      offstage: !_webVisible,
-                      child: WebViewWidget(controller: _controller!),
+                    child: IgnorePointer(
+                      ignoring: !_webVisible,
+                      child: ExcludeSemantics(
+                        excluding: !_webVisible,
+                        child: WebViewWidget(controller: _controller!),
+                      ),
+                    ),
+                  ),
+                if (!_webVisible)
+                  Positioned.fill(
+                    child: ColoredBox(
+                      color: Theme.of(context).scaffoldBackgroundColor,
+                      child: _content(),
                     ),
                   ),
                 if (_busy &&

--- a/lib/pages/elrc_recordings_page.dart
+++ b/lib/pages/elrc_recordings_page.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 import '../services/elrc_client.dart';
+import '../services/service_provider.dart';
+import '../services/third_party_auth_service.dart';
 import '../widgets/adaptive_page_navigation.dart';
 import 'elrc_player_page.dart';
 
@@ -40,6 +42,9 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
   bool _sessionReloadRequired = false;
   bool _loginPresented = false;
   var _expectedMainFrameCancellations = 0;
+  ThirdPartyAuthService? _tpAuth;
+  int _bindingGeneration = -1;
+  bool _campusAttempted = false;
 
   bool get _supported =>
       !kIsWeb &&
@@ -47,20 +52,54 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
           defaultTargetPlatform == TargetPlatform.android);
 
   @override
-  void initState() {
-    super.initState();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_tpAuth != null) return;
+    _tpAuth = ServiceProvider.of(context).thirdPartyAuthService;
+    _bindingGeneration = _tpAuth!.cpdailyNode.generation;
+    _tpAuth!.addListener(_bindingChanged);
+    if (_supported) unawaited(_prepare());
+  }
+
+  void _bindingChanged() {
+    final generation = _tpAuth!.cpdailyNode.generation;
+    if (generation == _bindingGeneration || !mounted) return;
+    _bindingGeneration = generation;
+    _request++;
+    _campusAttempted = false;
+    _loginPresented = false;
+    _client?.dispose();
+    _client = null;
+    _controller = null;
+    setState(() {
+      _courses = null;
+      _lessons = null;
+      _selectedCourse = null;
+      _busy = false;
+      _starting = true;
+      _webVisible = false;
+    });
     if (_supported) unawaited(_prepare());
   }
 
   Future<void> _prepare() async {
+    final generation = _bindingGeneration;
     final controller = WebViewController();
     final client = ElrcClient(controller);
     try {
+      await _tpAuth!.campusWebSession.prepare();
+      if (!mounted || generation != _bindingGeneration) {
+        client.dispose();
+        return;
+      }
       await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
       await client.initialize();
       await controller.setNavigationDelegate(
         NavigationDelegate(
           onNavigationRequest: (request) {
+            if (!identical(_controller, controller)) {
+              return NavigationDecision.prevent;
+            }
             final uri = Uri.tryParse(request.url);
             _trace('navigation request ${_safeUri(uri)}');
             if (request.url == 'about:blank') {
@@ -75,27 +114,39 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
               );
               return NavigationDecision.prevent;
             }
+            if (_isLogin(uri) &&
+                !_campusAttempted &&
+                _tpAuth!.hasCpdailyBinding) {
+              _expectedMainFrameCancellations++;
+              unawaited(_openLogin());
+              return NavigationDecision.prevent;
+            }
             if (_isHttpsElrc(uri) || _isLogin(uri)) {
               return NavigationDecision.navigate;
             }
             return NavigationDecision.prevent;
           },
           onPageStarted: (url) {
+            if (!identical(_controller, controller)) return;
             _trace('page started ${_safeUri(Uri.tryParse(url))}');
             _activate(url, pageStarted: true);
           },
           onUrlChange: (change) {
+            if (!identical(_controller, controller)) return;
             _trace('URL changed ${_safeUri(Uri.tryParse(change.url ?? ''))}');
             _activate(change.url);
           },
           onPageFinished: (url) {
+            if (!identical(_controller, controller)) return;
             _trace('page finished ${_safeUri(Uri.tryParse(url))}');
             _navigationFinished(url);
           },
-          onWebResourceError: _webResourceFailed,
+          onWebResourceError: (error) {
+            if (identical(_controller, controller)) _webResourceFailed(error);
+          },
         ),
       );
-      if (!mounted) {
+      if (!mounted || generation != _bindingGeneration) {
         client.dispose();
         return;
       }
@@ -105,7 +156,7 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
       await controller.loadRequest(_reviewUri);
     } catch (_) {
       client.dispose();
-      if (!mounted) return;
+      if (!mounted || generation != _bindingGeneration) return;
       if (identical(_client, client)) {
         _client = null;
         _controller = null;
@@ -137,7 +188,8 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
       (uri?.path == '/learn/videoreview' || uri?.path == '/learn/videoreview/');
 
   bool _isAppSide(Uri? uri) =>
-      _isHttpsElrc(uri) && (uri?.path == '/appside' || uri?.path == '/appside/');
+      _isHttpsElrc(uri) &&
+      (uri?.path == '/appside' || uri?.path == '/appside/');
 
   bool _isSessionPage(Uri? uri) => _isReview(uri) || _isAppSide(uri);
 
@@ -275,7 +327,16 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
       _sessionReloadRequired = true;
     });
     _trace('opening fixed ELRC login entry');
+    final request = ++_request;
     try {
+      if (!_campusAttempted) {
+        _campusAttempted = true;
+        final reused = await _tpAuth!.campusWebSession.useIdsSession();
+        _trace(reused
+            ? 'IDS cookie prepared; awaiting official SSO'
+            : 'manual login required',);
+      }
+      if (!mounted || request != _request) return;
       await controller.loadRequest(_loginUri);
     } catch (_) {
       if (!mounted) return;
@@ -300,7 +361,7 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
     try {
       final courses = await client.courses();
       if (!mounted || request != _request) return;
-      _trace('course request completed with ${courses.length} courses');
+      _trace('course request completed');
       if (courses.isEmpty && !_loginPresented) {
         _trace('empty initial course list; opening login');
         await _openLogin();
@@ -313,7 +374,7 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
       });
     } on ElrcException catch (error) {
       if (!mounted || request != _request) return;
-      _trace('course request failed: ${error.message}');
+      _trace('course request failed; needsLogin=${error.needsLogin}');
       if (error.needsLogin) {
         await _openLogin();
         return;
@@ -501,7 +562,8 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
             Card.outlined(
               child: ListTile(
                 title: Text(lesson.title),
-                subtitle: lesson.weekDate.isEmpty ? null : Text(lesson.weekDate),
+                subtitle:
+                    lesson.weekDate.isEmpty ? null : Text(lesson.weekDate),
                 trailing: const Icon(Icons.play_circle_outline),
                 onTap: _busy ? null : () => unawaited(_openLesson(lesson)),
               ),
@@ -542,7 +604,8 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
             child: ListTile(
               leading: const Icon(Icons.video_library_outlined),
               title: Text(course.name),
-              subtitle: course.description.isEmpty ? null : Text(course.description),
+              subtitle:
+                  course.description.isEmpty ? null : Text(course.description),
               trailing: const Icon(Icons.chevron_right),
               onTap: _busy ? null : () => unawaited(_loadLessons(course)),
             ),
@@ -554,6 +617,7 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
   @override
   void dispose() {
     _request++;
+    _tpAuth?.removeListener(_bindingChanged);
     _client?.dispose();
     _client = null;
     _controller = null;
@@ -600,7 +664,9 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
                       child: WebViewWidget(controller: _controller!),
                     ),
                   ),
-                if (_busy && (_courses != null || _lessons != null) && !_webVisible)
+                if (_busy &&
+                    (_courses != null || _lessons != null) &&
+                    !_webVisible)
                   const Align(
                     alignment: Alignment.topCenter,
                     child: LinearProgressIndicator(),

--- a/lib/pages/elrc_recordings_page.dart
+++ b/lib/pages/elrc_recordings_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
+import '../services/auth_service.dart';
 import '../services/elrc_client.dart';
 import '../services/service_provider.dart';
 import '../services/third_party_auth_service.dart';
@@ -43,6 +44,8 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
   bool _loginPresented = false;
   var _expectedMainFrameCancellations = 0;
   ThirdPartyAuthService? _tpAuth;
+  AuthService? _auth;
+  String? _primaryUserId;
   int _bindingGeneration = -1;
   bool _campusAttempted = false;
 
@@ -55,10 +58,39 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (_tpAuth != null) return;
-    _tpAuth = ServiceProvider.of(context).thirdPartyAuthService;
+    final services = ServiceProvider.of(context);
+    _tpAuth = services.thirdPartyAuthService;
+    _auth = services.authService;
+    _primaryUserId = _auth!.session?.userId;
+    _auth!.addListener(_primaryAccountChanged);
+    if (!_auth!.isLoggedIn) {
+      _starting = false;
+      _error = '请先登录 TechPie';
+      return;
+    }
     _bindingGeneration = _tpAuth!.cpdailyNode.generation;
     _tpAuth!.addListener(_bindingChanged);
     if (_supported) unawaited(_prepare());
+  }
+
+  bool get _authorized =>
+      _auth!.isLoggedIn && _auth!.session?.userId == _primaryUserId;
+
+  void _primaryAccountChanged() {
+    if (_authorized || !mounted) return;
+    _request++;
+    _client?.dispose();
+    _client = null;
+    _controller = null;
+    setState(() {
+      _courses = null;
+      _lessons = null;
+      _selectedCourse = null;
+      _starting = false;
+      _webVisible = false;
+      _error = '请先登录 TechPie';
+    });
+    Navigator.of(context).popUntil((route) => route.isFirst);
   }
 
   void _bindingChanged() {
@@ -87,8 +119,9 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
     final controller = WebViewController();
     final client = ElrcClient(controller);
     try {
-      await _tpAuth!.campusWebSession.prepare();
-      if (!mounted || generation != _bindingGeneration) {
+      await _tpAuth!.campusWebSession.useIdsSession();
+      _campusAttempted = true;
+      if (!mounted || !_authorized || generation != _bindingGeneration) {
         client.dispose();
         return;
       }
@@ -97,7 +130,7 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
       await controller.setNavigationDelegate(
         NavigationDelegate(
           onNavigationRequest: (request) {
-            if (!identical(_controller, controller)) {
+            if (!_authorized || !identical(_controller, controller)) {
               return NavigationDecision.prevent;
             }
             final uri = Uri.tryParse(request.url);
@@ -146,7 +179,7 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
           },
         ),
       );
-      if (!mounted || generation != _bindingGeneration) {
+      if (!mounted || !_authorized || generation != _bindingGeneration) {
         client.dispose();
         return;
       }
@@ -302,7 +335,7 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
     try {
       await controller.loadRequest(_reviewUri);
     } catch (_) {
-      if (!mounted || request != _request) return;
+      if (!mounted || !_authorized || request != _request) return;
       setState(() {
         _starting = false;
         _sessionReloadRequired = true;
@@ -332,9 +365,11 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
       if (!_campusAttempted) {
         _campusAttempted = true;
         final reused = await _tpAuth!.campusWebSession.useIdsSession();
-        _trace(reused
-            ? 'IDS cookie prepared; awaiting official SSO'
-            : 'manual login required',);
+        _trace(
+          reused
+              ? 'IDS cookie prepared; awaiting official SSO'
+              : 'manual login required',
+        );
       }
       if (!mounted || request != _request) return;
       await controller.loadRequest(_loginUri);
@@ -616,6 +651,7 @@ class _ElrcRecordingsPageState extends State<ElrcRecordingsPage> {
 
   @override
   void dispose() {
+    _auth?.removeListener(_primaryAccountChanged);
     _request++;
     _tpAuth?.removeListener(_bindingChanged);
     _client?.dispose();

--- a/lib/pages/generic_webview_page.dart
+++ b/lib/pages/generic_webview_page.dart
@@ -5,9 +5,15 @@ import 'package:desktop_webview_window/desktop_webview_window.dart'
     show WebviewWindow, CreateConfiguration;
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart'
-    show WebViewController, JavaScriptMode, NavigationDelegate,
-         NavigationDecision, WebViewWidget, WebViewCookie,
-         WebViewCookieManager;
+    show
+        WebViewController,
+        JavaScriptMode,
+        NavigationDelegate,
+        NavigationDecision,
+        WebViewWidget;
+
+import '../services/service_provider.dart';
+import '../services/third_party_auth_service.dart';
 
 /// A page that hosts a webview.
 ///
@@ -20,12 +26,10 @@ class GenericWebViewPage extends StatefulWidget {
     super.key,
     required this.title,
     required this.url,
-    this.cookies,
   });
 
   final String title;
   final String url;
-  final List<WebViewCookie>? cookies;
 
   @override
   State<GenericWebViewPage> createState() => _GenericWebViewPageState();
@@ -34,9 +38,17 @@ class GenericWebViewPage extends StatefulWidget {
 class _GenericWebViewPageState extends State<GenericWebViewPage> {
   late final WebViewController _controller;
 
+  ThirdPartyAuthService? _tpAuth;
+  int _generation = -1;
+  String? _error;
+
   @override
-  void initState() {
-    super.initState();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_tpAuth != null) return;
+    _tpAuth = ServiceProvider.of(context).thirdPartyAuthService;
+    _generation = _tpAuth!.cpdailyNode.generation;
+    _tpAuth!.addListener(_bindingChanged);
     if (Platform.isLinux || Platform.isWindows) {
       unawaited(_openDesktop());
     } else {
@@ -45,11 +57,20 @@ class _GenericWebViewPageState extends State<GenericWebViewPage> {
     }
   }
 
+  void _bindingChanged() {
+    if (_generation == _tpAuth!.cpdailyNode.generation) return;
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  @override
+  void dispose() {
+    _tpAuth?.removeListener(_bindingChanged);
+    super.dispose();
+  }
+
   // -- Desktop path (desktop_webview_window popup) --
 
   Future<void> _openDesktop() async {
-    final cookies = widget.cookies ?? const <WebViewCookie>[];
-
     final webview = await WebviewWindow.create(
       configuration: CreateConfiguration(
         title: widget.title,
@@ -58,17 +79,6 @@ class _GenericWebViewPageState extends State<GenericWebViewPage> {
       ),
     );
 
-    for (final c in cookies) {
-      webview.setCookie(
-        url: widget.url,
-        name: c.name,
-        value: c.value,
-        domain: c.domain,
-        path: c.path,
-        isHttpOnly: true,
-      );
-    }
-
     webview.launch(widget.url);
     if (mounted) Navigator.of(context).pop();
   }
@@ -76,20 +86,20 @@ class _GenericWebViewPageState extends State<GenericWebViewPage> {
   // -- Mobile / webview_flutter in-app widget --
 
   Future<void> _initController() async {
-    await _controller.setJavaScriptMode(JavaScriptMode.unrestricted);
-    await _controller.setNavigationDelegate(
-      NavigationDelegate(
-        onNavigationRequest: (request) => NavigationDecision.navigate,
-      ),
-    );
+    try {
+      await _controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+      await _controller.setNavigationDelegate(
+        NavigationDelegate(
+          onNavigationRequest: (request) => NavigationDecision.navigate,
+        ),
+      );
 
-    final cookieManager = WebViewCookieManager();
-    await cookieManager.clearCookies();
-    for (final c in widget.cookies ?? const <WebViewCookie>[]) {
-      await cookieManager.setCookie(c);
+      await _tpAuth!.campusWebSession.useIdsSession();
+      if (!mounted || _generation != _tpAuth!.cpdailyNode.generation) return;
+      await _controller.loadRequest(Uri.parse(widget.url));
+    } catch (_) {
+      if (mounted) setState(() => _error = '校园网页加载失败，请稍后重试');
     }
-
-    await _controller.loadRequest(Uri.parse(widget.url));
   }
 
   @override
@@ -103,7 +113,9 @@ class _GenericWebViewPageState extends State<GenericWebViewPage> {
 
     return Scaffold(
       appBar: AppBar(title: Text(widget.title), centerTitle: true),
-      body: WebViewWidget(controller: _controller),
+      body: _error == null
+          ? WebViewWidget(controller: _controller)
+          : Center(child: Text(_error!)),
     );
   }
 }

--- a/lib/pages/generic_webview_page.dart
+++ b/lib/pages/generic_webview_page.dart
@@ -12,6 +12,7 @@ import 'package:webview_flutter/webview_flutter.dart'
         NavigationDecision,
         WebViewWidget;
 
+import '../services/auth_service.dart';
 import '../services/service_provider.dart';
 import '../services/third_party_auth_service.dart';
 
@@ -39,6 +40,8 @@ class _GenericWebViewPageState extends State<GenericWebViewPage> {
   late final WebViewController _controller;
 
   ThirdPartyAuthService? _tpAuth;
+  AuthService? _auth;
+  String? _primaryUserId;
   int _generation = -1;
   String? _error;
 
@@ -46,7 +49,15 @@ class _GenericWebViewPageState extends State<GenericWebViewPage> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (_tpAuth != null) return;
-    _tpAuth = ServiceProvider.of(context).thirdPartyAuthService;
+    final services = ServiceProvider.of(context);
+    _tpAuth = services.thirdPartyAuthService;
+    _auth = services.authService;
+    _primaryUserId = _auth!.session?.userId;
+    _auth!.addListener(_primaryAccountChanged);
+    if (!_auth!.isLoggedIn) {
+      _error = '请先登录 TechPie';
+      return;
+    }
     _generation = _tpAuth!.cpdailyNode.generation;
     _tpAuth!.addListener(_bindingChanged);
     if (Platform.isLinux || Platform.isWindows) {
@@ -62,8 +73,18 @@ class _GenericWebViewPageState extends State<GenericWebViewPage> {
     if (mounted) Navigator.of(context).pop();
   }
 
+  bool get _authorized =>
+      _auth!.isLoggedIn && _auth!.session?.userId == _primaryUserId;
+
+  void _primaryAccountChanged() {
+    if (_authorized || !mounted) return;
+    setState(() => _error = '请先登录 TechPie');
+    Navigator.of(context).popUntil((route) => route.isFirst);
+  }
+
   @override
   void dispose() {
+    _auth?.removeListener(_primaryAccountChanged);
     _tpAuth?.removeListener(_bindingChanged);
     super.dispose();
   }
@@ -90,12 +111,18 @@ class _GenericWebViewPageState extends State<GenericWebViewPage> {
       await _controller.setJavaScriptMode(JavaScriptMode.unrestricted);
       await _controller.setNavigationDelegate(
         NavigationDelegate(
-          onNavigationRequest: (request) => NavigationDecision.navigate,
+          onNavigationRequest: (request) => _authorized
+              ? NavigationDecision.navigate
+              : NavigationDecision.prevent,
         ),
       );
 
       await _tpAuth!.campusWebSession.useIdsSession();
-      if (!mounted || _generation != _tpAuth!.cpdailyNode.generation) return;
+      if (!mounted ||
+          !_authorized ||
+          _generation != _tpAuth!.cpdailyNode.generation) {
+        return;
+      }
       await _controller.loadRequest(Uri.parse(widget.url));
     } catch (_) {
       if (mounted) setState(() => _error = '校园网页加载失败，请稍后重试');

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:webview_flutter/webview_flutter.dart';
 
 import '../models/assignment.dart';
 import '../models/course.dart';
@@ -399,7 +398,6 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
         feature.nativeEntry?.call(context);
         break;
       case FeatureMode.webviewWithCookie:
-        final cookies = _buildCookiesForFeature(feature.cookieType);
         if (feature.url != null) {
           unawaited(
             pushAdaptivePage<void>(
@@ -407,50 +405,12 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
               builder: (_) => GenericWebViewPage(
                 title: feature.description,
                 url: feature.url!,
-                cookies: cookies,
               ),
             ),
           );
         }
         break;
     }
-  }
-
-  List<WebViewCookie> _buildCookiesForFeature(CookieType? cookieType) {
-    final cookies = <WebViewCookie>[];
-    if (cookieType == null) return cookies;
-
-    final sp = ServiceProvider.of(context);
-    // ecourse / student-leave / eams webviews all authenticate against the
-    // CpDaily session, whose cookies are exposed by the cpdaily session node
-    // (the CASTGC-bearing cookie set that webviews consume directly). Read
-    // it through the unified [CookieProvider] view so the source is abstracted.
-    final cp = sp.thirdPartyAuthService.cpdailyNode.cookieProvider;
-    if (cp == null || cp.isEmpty) return cookies;
-
-    final domain = cp.domain.isNotEmpty
-        ? cp.domain
-        : 'ids.shanghaitech.edu.cn';
-
-    for (final part in cp.cookies.split(';')) {
-      final idx = part.indexOf('=');
-      if (idx > 0) {
-        final key = part.substring(0, idx).trim();
-        final value = part.substring(idx + 1).trim();
-        if (key.isNotEmpty && value.isNotEmpty) {
-          cookies.add(
-            WebViewCookie(
-              name: key,
-              value: value,
-              domain: domain,
-              path: '/',
-            ),
-          );
-        }
-      }
-    }
-
-    return cookies;
   }
 
   Widget _buildTodayClasses(ThemeData theme, bool isLoggedIn) {

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -393,6 +393,10 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
   }
 
   void _handleFeatureTap(Feature feature) {
+    if (!ServiceProvider.of(context).authService.isLoggedIn) {
+      unawaited(presentLoginPage(context));
+      return;
+    }
     switch (feature.mode) {
       case FeatureMode.native:
         feature.nativeEntry?.call(context);

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -129,6 +129,7 @@ class AuthService extends ChangeNotifier {
 
   Future<void> logout() async {
     _session = null;
+    notifyListeners();
     await _storage.clearSession();
     if (onLogout != null) {
       try {

--- a/lib/services/campus_web_session.dart
+++ b/lib/services/campus_web_session.dart
@@ -118,7 +118,6 @@ class CampusWebSession {
     final owner = _owner;
     final revision = _authRevision;
     final generation = node.generation;
-    final epoch = node.epoch;
     return _queue(() async {
       await _syncOwner();
       void checkOwner() {
@@ -132,18 +131,19 @@ class CampusWebSession {
 
       checkOwner();
       if (node.account == null) return false;
-      // Reuse the existing single-flight renewal before handing IDS its TGC.
-      final renewed = await node.renewIfNeeded(epoch);
+      final manager = CookieManager.instance();
+      final ids = WebUri('https://ids.shanghaitech.edu.cn/authserver/');
+      // A browser login can be newer than the saved CpDaily binding. Preserve
+      // it and let IDS validate the session through the service's SSO redirect.
+      final existing = await manager.getCookie(url: ids, name: 'CASTGC');
       checkOwner();
-      if (!renewed) {
-        if (node.lastRenewWasCredentialError) return false;
-        throw node.lastFailure ?? SessionFailure.unavailable;
-      }
+      final currentTgc = existing?.value;
+      if (currentTgc is String && currentTgc.isNotEmpty) return true;
       final tgc = node.rawFields['tgc'] as String? ?? '';
       if (tgc.isEmpty) return false;
       for (final name in const ['CASTGC', 'AUTHTGC']) {
-        final saved = await CookieManager.instance().setCookie(
-          url: WebUri('https://ids.shanghaitech.edu.cn/authserver/'),
+        final saved = await manager.setCookie(
+          url: ids,
           name: name,
           value: tgc,
           path: '/authserver',

--- a/lib/services/campus_web_session.dart
+++ b/lib/services/campus_web_session.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
+import 'auth_service.dart';
 import 'session/session_failure.dart';
 import 'session/session_node.dart';
 import 'storage_service.dart';
@@ -15,14 +17,42 @@ class CampusWebSession {
 
   final SessionNode node;
   final StorageService storage;
+  AuthService? _auth;
+  String? _primaryUserId;
+  int _authRevision = 0;
+  int _clearedAuthRevision = 0;
   Future<void> _pending = Future.value();
   bool get supported =>
       !kIsWeb &&
       (defaultTargetPlatform == TargetPlatform.iOS ||
+          defaultTargetPlatform == TargetPlatform.macOS ||
           defaultTargetPlatform == TargetPlatform.android);
-  String get _owner => node.account == null
-      ? 'unbound'
-      : '${node.identityKey}:${node.account!.boundAt.toIso8601String()}';
+  String get _owner {
+    final userId = _auth?.session?.userId;
+    if (userId == null) return 'signed-out';
+    final binding = node.account == null
+        ? 'unbound'
+        : '${node.identityKey}:${node.account!.boundAt.toIso8601String()}';
+    return jsonEncode([userId, binding]);
+  }
+
+  void attachAuth(AuthService auth) {
+    if (identical(_auth, auth)) return;
+    _auth?.removeListener(_onPrimaryAccountChanged);
+    _auth = auth;
+    _primaryUserId = auth.session?.userId;
+    auth.addListener(_onPrimaryAccountChanged);
+    _onBindingChanged();
+  }
+
+  void _onPrimaryAccountChanged() {
+    final userId = _auth?.session?.userId;
+    if (_primaryUserId == userId) return;
+    _primaryUserId = userId;
+    _authRevision++;
+    node.cancelPendingRequests();
+    _onBindingChanged();
+  }
 
   void _onBindingChanged() {
     unawaited(
@@ -43,10 +73,14 @@ class CampusWebSession {
 
   Future<void> _syncOwner() async {
     final owner = _owner;
-    if (storage.campusWebOwner == owner) return;
+    final revision = _authRevision;
+    if (storage.campusWebOwner == owner && _clearedAuthRevision == revision) {
+      return;
+    }
     final manager = CookieManager.instance();
     final webStorage = WebStorageManager.instance();
-    if (defaultTargetPlatform == TargetPlatform.iOS) {
+    if (defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.macOS) {
       for (final cookie in await manager.getAllCookies()) {
         final domain = cookie.domain ?? '';
         if (!_schoolDomain(domain)) continue;
@@ -68,10 +102,12 @@ class CampusWebSession {
     } else {
       // Android cannot enumerate cookie domains/paths. Its shared App store
       // is reset on binding replacement, including other embedded web logins.
+      // False means the store was already empty, not that deletion failed.
       await manager.deleteAllCookies();
       await webStorage.deleteAllData();
     }
     await storage.setCampusWebOwner(owner);
+    _clearedAuthRevision = revision;
     if (kDebugMode) {
       debugPrint('[CampusWeb] binding changed; web session cleared');
     }
@@ -79,10 +115,30 @@ class CampusWebSession {
 
   Future<bool> useIdsSession() {
     if (!supported) return Future.value(false);
+    final owner = _owner;
+    final revision = _authRevision;
     final generation = node.generation;
+    final epoch = node.epoch;
     return _queue(() async {
       await _syncOwner();
-      if (node.generation != generation) throw SessionFailure.changed;
+      void checkOwner() {
+        if (_auth?.isLoggedIn != true ||
+            _authRevision != revision ||
+            _owner != owner ||
+            node.generation != generation) {
+          throw SessionFailure.changed;
+        }
+      }
+
+      checkOwner();
+      if (node.account == null) return false;
+      // Reuse the existing single-flight renewal before handing IDS its TGC.
+      final renewed = await node.renewIfNeeded(epoch);
+      checkOwner();
+      if (!renewed) {
+        if (node.lastRenewWasCredentialError) return false;
+        throw node.lastFailure ?? SessionFailure.unavailable;
+      }
       final tgc = node.rawFields['tgc'] as String? ?? '';
       if (tgc.isEmpty) return false;
       for (final name in const ['CASTGC', 'AUTHTGC']) {
@@ -95,9 +151,7 @@ class CampusWebSession {
           isHttpOnly: true,
         );
         if (!saved) throw SessionFailure.unavailable;
-      }
-      if (node.generation != generation) {
-        throw SessionFailure.changed;
+        checkOwner();
       }
       return true;
     });
@@ -107,5 +161,8 @@ class CampusWebSession {
       domain == 'shanghaitech.edu.cn' ||
       domain.endsWith('.shanghaitech.edu.cn');
 
-  void dispose() => node.removeListener(_onBindingChanged);
+  void dispose() {
+    _auth?.removeListener(_onPrimaryAccountChanged);
+    node.removeListener(_onBindingChanged);
+  }
 }

--- a/lib/services/campus_web_session.dart
+++ b/lib/services/campus_web_session.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+import 'session/session_failure.dart';
+import 'session/session_node.dart';
+import 'storage_service.dart';
+
+/// Coordinates the App's campus WebViews, which share one native cookie store.
+class CampusWebSession {
+  CampusWebSession(this.node, this.storage) {
+    node.addListener(_onBindingChanged);
+  }
+
+  final SessionNode node;
+  final StorageService storage;
+  Future<void> _pending = Future.value();
+  bool get supported =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.iOS ||
+          defaultTargetPlatform == TargetPlatform.android);
+  String get _owner => node.account == null
+      ? 'unbound'
+      : '${node.identityKey}:${node.account!.boundAt.toIso8601String()}';
+
+  void _onBindingChanged() {
+    unawaited(
+      prepare().catchError((Object _) {
+        if (kDebugMode) debugPrint('[CampusWeb] session reset failed');
+      }),
+    );
+  }
+
+  Future<T> _queue<T>(Future<T> Function() action) {
+    final operation = _pending.then((_) => action());
+    _pending =
+        operation.then<void>((_) {}, onError: (Object _, StackTrace __) {});
+    return operation;
+  }
+
+  Future<void> prepare() => !supported ? Future.value() : _queue(_syncOwner);
+
+  Future<void> _syncOwner() async {
+    final owner = _owner;
+    if (storage.campusWebOwner == owner) return;
+    final manager = CookieManager.instance();
+    final webStorage = WebStorageManager.instance();
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      for (final cookie in await manager.getAllCookies()) {
+        final domain = cookie.domain ?? '';
+        if (!_schoolDomain(domain)) continue;
+        await manager.deleteCookie(
+          url: WebUri('https://${domain.replaceFirst(RegExp(r'^\.'), '')}/'),
+          name: cookie.name,
+          domain: domain,
+          path: cookie.path ?? '/',
+        );
+      }
+      final records =
+          await webStorage.fetchDataRecords(dataTypes: WebsiteDataType.ALL);
+      await webStorage.removeDataFor(
+        dataTypes: WebsiteDataType.ALL,
+        dataRecords: records
+            .where((record) => _schoolDomain(record.displayName ?? ''))
+            .toList(),
+      );
+    } else {
+      // Android cannot enumerate cookie domains/paths. Its shared App store
+      // is reset on binding replacement, including other embedded web logins.
+      await manager.deleteAllCookies();
+      await webStorage.deleteAllData();
+    }
+    await storage.setCampusWebOwner(owner);
+    if (kDebugMode) {
+      debugPrint('[CampusWeb] binding changed; web session cleared');
+    }
+  }
+
+  Future<bool> useIdsSession() {
+    if (!supported) return Future.value(false);
+    final generation = node.generation;
+    return _queue(() async {
+      await _syncOwner();
+      if (node.generation != generation) throw SessionFailure.changed;
+      final tgc = node.rawFields['tgc'] as String? ?? '';
+      if (tgc.isEmpty) return false;
+      for (final name in const ['CASTGC', 'AUTHTGC']) {
+        final saved = await CookieManager.instance().setCookie(
+          url: WebUri('https://ids.shanghaitech.edu.cn/authserver/'),
+          name: name,
+          value: tgc,
+          path: '/authserver',
+          isSecure: true,
+          isHttpOnly: true,
+        );
+        if (!saved) throw SessionFailure.unavailable;
+      }
+      if (node.generation != generation) {
+        throw SessionFailure.changed;
+      }
+      return true;
+    });
+  }
+
+  bool _schoolDomain(String domain) =>
+      domain == 'shanghaitech.edu.cn' ||
+      domain.endsWith('.shanghaitech.edu.cn');
+
+  void dispose() => node.removeListener(_onBindingChanged);
+}

--- a/lib/services/session/session_node.dart
+++ b/lib/services/session/session_node.dart
@@ -135,6 +135,16 @@ class SessionNode extends ChangeNotifier {
 
   int _generation = 0;
   int get generation => parent?.generation ?? _generation;
+
+  /// Discard pending requests without deleting the saved account binding.
+  void cancelPendingRequests() {
+    _generation++;
+    _renewInFlight = null;
+    for (final child in _children) {
+      child.cancelPendingRequests();
+    }
+  }
+
   SessionFailure? lastFailure;
   DateTime? verifiedAt;
 

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -31,6 +31,10 @@ class StorageService {
           aOptions: AndroidOptions(encryptedSharedPreferences: true),
         );
 
+  String? get campusWebOwner => _prefs.getString('campus_web_owner');
+  Future<void> setCampusWebOwner(String owner) =>
+      _prefs.setString('campus_web_owner', owner);
+
   // Secure session storage
   Future<void> saveSession(UserSession session) async {
     await _writeCredential(() =>

--- a/lib/services/third_party_auth_service.dart
+++ b/lib/services/third_party_auth_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 
 import '../models/third_party_account.dart';
 import 'api_base_url.dart';
+import 'campus_web_session.dart';
 import 'http_client.dart';
 import 'session/session_node.dart';
 import 'session/session_tree.dart';
@@ -36,6 +37,9 @@ class ThirdPartyAuthService extends ChangeNotifier {
   }
 
   late final SessionTree _tree;
+  CampusWebSession? _webSession;
+  CampusWebSession get campusWebSession =>
+      _webSession ??= CampusWebSession(cpdailyNode, _storage);
   // Stable per-device id, loaded in [initialize]. Stamped onto every locally
   // mutated account so the cloud-sync LWW merge converges.
   String _deviceId = '';
@@ -573,6 +577,7 @@ class ThirdPartyAuthService extends ChangeNotifier {
 
   @override
   void dispose() {
+    _webSession?.dispose();
     _tree.removeListener(_onTreeChanged);
     _tree.dispose();
     super.dispose();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -160,7 +160,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_inappwebview:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_inappwebview
       sha256: "80092d13d3e29b6227e25b67973c67c7210bd5e35c4b747ca908e31eb71a46d5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   dynamic_color: ">=1.7.0 <1.8.0"
   flutter:
     sdk: flutter
+  flutter_inappwebview: 6.1.5
   flutter_secure_storage: ^9.2.4
   http: ^1.4.0
   intl: ^0.20.2


### PR DESCRIPTION
退出 TechPie 后，课程录播、E云课堂、学生请假和场馆预约统一要求重新登录；关闭已打开的校园页面并清理学校网页会话。退出或更换主账号会使正在进行的续期及旧页面回调失效，已保存的校园绑定保留。

进入校园页面时优先复用有效 IDS 票据，通过学校官方 SSO 建立各服务自己的会话。录播不再强制经过 CpDaily 续期，因此 CpDaily 接口故障不会挡住仍然有效的 IDS 登录。

macOS 已开放课程录播：正确处理 WebKit 向原生播放器交接的 204，保持用于请求课程信息的 WebView 附着，避免隐藏 WebView 被暂停后超时。

依赖 #92。iOS/macOS 只清理学校域名；Android 受原生接口限制，清理本 App 内嵌网页共享登录存储。

验证：29 项校园会话与录播回归通过；Mac ARM64 开发签名构建通过。真实已绑定账号验证了 ELRC 课程列表、多个课时播放、暂停/恢复、画面切换，以及 E云课堂课程详情和学生请假记录的会话复用。测试及脚本未纳入提交。

保留 Draft：真实账号退出后重新登录、切换校园账号以及 iPhone/iPad 上的业务验收仍需完成。Mac 验收包不等于已发布 App Store 版本。
