### PR TITLE
feat(calendar): 管理随 App 同步更新的课表订阅

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:techpie/utils/platform.dart';
 import 'models/third_party_account.dart';
 import 'services/assignment_service.dart';
 import 'services/auth_service.dart';
+import 'services/calendar_subscription_service.dart';
 import 'services/debug_logger.dart';
 import 'services/http_client.dart';
 import 'services/oa_gym_service.dart';
@@ -255,6 +256,25 @@ class TechPieApp extends StatefulWidget {
 }
 
 class _TechPieAppState extends State<TechPieApp> {
+  late final CalendarSubscriptionService _calendarSubscriptionService;
+
+  @override
+  void initState() {
+    super.initState();
+    _calendarSubscriptionService = CalendarSubscriptionService(
+      widget.authService,
+      widget.storageService,
+      widget.scheduleService,
+    );
+    unawaited(_calendarSubscriptionService.initialize());
+  }
+
+  @override
+  void dispose() {
+    _calendarSubscriptionService.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return DynamicColorBuilder(
@@ -277,6 +297,7 @@ class _TechPieAppState extends State<TechPieApp> {
         themeService: widget.themeService,
         scheduleService: widget.scheduleService,
         assignmentService: widget.assignmentService,
+        calendarSubscriptionService: _calendarSubscriptionService,
         thirdPartyAuthService: widget.thirdPartyAuthService,
         oaGymService: widget.oaGymService,
         uniAuthService: widget.uniAuthService,

--- a/lib/pages/calendar_subscription_page.dart
+++ b/lib/pages/calendar_subscription_page.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../services/calendar_subscription_service.dart';
+import '../services/service_provider.dart';
+import '../widgets/adaptive_alert_dialog.dart';
+import '../widgets/adaptive_feedback.dart';
+import 'login_page.dart';
+
+class CalendarSubscriptionPage extends StatefulWidget {
+  const CalendarSubscriptionPage({super.key});
+  @override
+  State<CalendarSubscriptionPage> createState() =>
+      _CalendarSubscriptionPageState();
+}
+
+class _CalendarSubscriptionPageState extends State<CalendarSubscriptionPage> {
+  CalendarSubscriptionService? _service;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_service != null) return;
+    _service = ServiceProvider.of(context).calendarSubscriptionService;
+    unawaited(_act(_service!.reload));
+  }
+
+  Future<void> _act(Future<void> Function() action) async {
+    try {
+      await action();
+    } catch (_) {/* The service exposes the failure. */}
+  }
+
+  Future<void> _publish() async {
+    final confirmed = await showAdaptiveAlertDialog<bool>(
+      context: context,
+      title: _service!.enabled ? '更新为当前课表？' : '开启课表订阅？',
+      message: '服务器会保存当前学期的日历内容。此后 App 成功同步同一校园账号、同一学期的课表时，会更新订阅。'
+          '校园登录凭据不会随订阅上传。每个 TechPie 主账号保留一个订阅，持有链接的人可以读取课表。',
+      actions: const [
+        AdaptiveAlertAction(label: '取消', value: false),
+        AdaptiveAlertAction(label: '确认', value: true, isDefault: true),
+      ],
+    );
+    if (confirmed == true) await _act(_service!.publish);
+  }
+
+  Future<void> _revoke() async {
+    final confirmed = await showAdaptiveAlertDialog<bool>(
+      context: context,
+      title: '撤销课表订阅？',
+      message: '原链接将失效。日历 App 已保存的日程需要在日历 App 中删除。',
+      actions: const [
+        AdaptiveAlertAction(label: '取消', value: false),
+        AdaptiveAlertAction(label: '撤销', value: true, isDestructive: true),
+      ],
+    );
+    if (confirmed == true) await _act(_service!.revoke);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final service = _service!;
+    return Scaffold(
+      appBar: AppBar(title: const Text('课表订阅')),
+      body: ListenableBuilder(
+        listenable: service,
+        builder: (context, _) => ListView(
+          padding: const EdgeInsets.all(20),
+          children: [
+            const Text('日历 App 定期读取订阅链接；只有 TechPie 成功同步课表后，链接内容才会更新。'
+                '更新频率由日历 App 决定。180 天没有更新，链接自动失效。'),
+            const SizedBox(height: 20),
+            if (service.busy) const LinearProgressIndicator(),
+            if (service.error != null) ...[
+              Text(service.error!,
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),),
+              TextButton(
+                  onPressed: service.busy
+                      ? null
+                      : () => unawaited(_act(service.reload)),
+                  child: const Text('重新加载'),),
+              TextButton(
+                onPressed: service.busy
+                    ? null
+                    : () async {
+                        await presentLoginPage(context);
+                        if (mounted) await _act(service.reload);
+                      },
+                child: const Text('登录 TechPie 主账号'),
+              ),
+            ],
+            if (service.enabled) ...[
+              Text('上次上传：${service.updatedAt ?? "未知"}'),
+              Text('有效期至：${service.expiresAt ?? "未知"}'),
+              const SizedBox(height: 12),
+              OutlinedButton.icon(
+                icon: const Icon(Icons.copy),
+                label: const Text('复制订阅链接'),
+                onPressed: service.busy
+                    ? null
+                    : () async {
+                        await Clipboard.setData(
+                            ClipboardData(text: service.url!.toString()),);
+                        if (!context.mounted) return;
+                        showAdaptiveFeedback(
+                            context: context, message: '订阅链接已复制',);
+                      },
+              ),
+              OutlinedButton.icon(
+                icon: const Icon(Icons.calendar_month),
+                label: const Text('在日历 App 中订阅'),
+                onPressed: service.busy
+                    ? null
+                    : () async {
+                        final opened = await launchUrl(
+                            service.url!.replace(scheme: 'webcal'),
+                            mode: LaunchMode.externalApplication,);
+                        if (!opened && context.mounted) {
+                          showAdaptiveFeedback(
+                              context: context, message: '请复制链接，在日历 App 中添加订阅',);
+                        }
+                      },
+              ),
+            ],
+            FilledButton(
+              onPressed: service.busy ? null : _publish,
+              child: Text(service.enabled ? '更新为当前课表' : '开启订阅'),
+            ),
+            if (service.enabled)
+              TextButton(
+                  onPressed: service.busy ? null : _revoke,
+                  child: const Text('撤销订阅'),),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/schedule_page.dart
+++ b/lib/pages/schedule_page.dart
@@ -26,6 +26,7 @@ import '../widgets/course_detail_panel.dart';
 import '../widgets/desktop_popup.dart';
 import '../widgets/desktop_select_popover.dart';
 import '../widgets/ios/ios_native_navigation_bar.dart';
+import 'calendar_subscription_page.dart';
 import 'login_page.dart';
 import 'third_party_accounts_page.dart';
 import 'third_party_bind_page.dart';
@@ -386,6 +387,13 @@ class _SchedulePageState extends State<SchedulePage> {
   String get _defaultCalendarName =>
       _semesterLabel.isEmpty ? '课程表' : _semesterLabel;
 
+  void _openSubscription() => unawaited(
+        pushAdaptivePage<void>(
+          context,
+          builder: (_) => const CalendarSubscriptionPage(),
+        ),
+      );
+
   void _startExportCalendar() {
     if (_exportingCalendar) return;
     unawaited(_exportCalendar());
@@ -596,6 +604,10 @@ class _SchedulePageState extends State<SchedulePage> {
                       title: '',
                       displayInline: true,
                       children: [
+                        const IosNativeNavigationBarMenuItem(
+                            value: 'subscribeCalendar',
+                            title: '课表订阅',
+                            sfSymbol: 'calendar.badge.plus',),
                         IosNativeNavigationBarMenuItem(
                           value: 'exportCalendar',
                           title: _exportingCalendar ? '正在导出…' : '导出课表',
@@ -660,6 +672,11 @@ class _SchedulePageState extends State<SchedulePage> {
                 ],
               ),
               actions: [
+                IconButton(
+                  tooltip: '课表订阅',
+                  onPressed: _openSubscription,
+                  icon: const Icon(Icons.calendar_month_outlined),
+                ),
                 IconButton(
                   icon: const Icon(Icons.chevron_left),
                   tooltip: 'Previous week',
@@ -910,6 +927,8 @@ class _SchedulePageState extends State<SchedulePage> {
           _showGhostCourses = !_showGhostCourses;
           _filterCoursesForWeek();
         });
+      case 'subscribeCalendar':
+        _openSubscription();
       case 'exportCalendar':
         _startExportCalendar();
     }

--- a/lib/services/calendar_subscription_service.dart
+++ b/lib/services/calendar_subscription_service.dart
@@ -1,0 +1,199 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import 'api_base_url.dart';
+import 'auth_service.dart';
+import 'ics/ics_export_service.dart';
+import 'schedule_service.dart';
+import 'storage_service.dart';
+
+class CalendarSubscriptionException implements Exception {
+  const CalendarSubscriptionException(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+class CalendarSubscriptionService extends ChangeNotifier {
+  CalendarSubscriptionService(this.auth, this.storage, this.schedule,
+      {http.Client? client,})
+      : _client = client ?? http.Client() {
+    schedule.addListener(_scheduleChanged);
+  }
+  final AuthService auth;
+  final StorageService storage;
+  final ScheduleService schedule;
+  final http.Client _client;
+  Map<String, dynamic>? _record;
+  bool _busy = false;
+  String? _error;
+  DateTime? _observedUpdate;
+  bool get busy => _busy;
+  String? get error => _error;
+  Map<String, dynamic>? get _current =>
+      _record?['primaryId'] == auth.session?.userId &&
+              _record?['api'] == apiBaseUrl(storage)
+          ? _record
+          : null;
+  bool get enabled => _current?['id'] != null;
+  String? get updatedAt => _current?['updatedAt'] as String?;
+  String? get expiresAt => _current?['expiresAt'] as String?;
+  Uri? get url => !enabled
+      ? null
+      : Uri.parse(
+          '${apiBaseUrl(storage)}/calendar/subscribe/${_current!['id']}',);
+
+  Future<void> initialize() async {
+    _record = await storage.loadCalendarSubscription();
+    _observedUpdate = schedule.updatedAt;
+  }
+
+  void _scheduleChanged() {
+    final updated = schedule.updatedAt;
+    if (schedule.loading ||
+        schedule.error != null ||
+        updated == null ||
+        updated == _observedUpdate) {
+      return;
+    }
+    _observedUpdate = updated;
+    if (!enabled ||
+        _current?['campusOwner'] != schedule.owner ||
+        _current?['semester'] != schedule.selectedSemesterId ||
+        _busy) {
+      return;
+    }
+    unawaited(publish().catchError((Object _) {}));
+  }
+
+  Future<Map<String, dynamic>> _send(String method,
+      [Map<String, dynamic>? body,]) async {
+    final primaryId = auth.session?.userId;
+    if (primaryId == null) {
+      throw const CalendarSubscriptionException('请先登录 TechPie 主账号');
+    }
+    Future<http.Response> request() async {
+      final token = auth.session?.geekpieToken;
+      if (token == null || token.isEmpty || auth.session?.userId != primaryId) {
+        throw const CalendarSubscriptionException('请重新登录 TechPie 主账号');
+      }
+      final request = http.Request(
+          method, Uri.parse('${apiBaseUrl(storage)}/calendar/subscription'),)
+        ..headers.addAll({
+          'Authorization': 'Bearer $token',
+          'Content-Type': 'application/json',
+        });
+      if (body != null) request.body = jsonEncode(body);
+      return http.Response.fromStream(await _client.send(request));
+    }
+
+    try {
+      var response = await request().timeout(const Duration(seconds: 60));
+      if (response.statusCode == 401 && await auth.tryRenewSession()) {
+        response = await request().timeout(const Duration(seconds: 60));
+      }
+      if (auth.session?.userId != primaryId) {
+        throw const CalendarSubscriptionException('主账号已变更，请重新加载');
+      }
+      if (response.statusCode == 401) {
+        throw const CalendarSubscriptionException('请重新登录 TechPie 主账号');
+      }
+      if (response.statusCode == 409) {
+        throw const CalendarSubscriptionException('订阅已变更，请重新加载后操作');
+      }
+      if (response.statusCode == 404 || response.statusCode == 503) {
+        throw const CalendarSubscriptionException('课表订阅服务暂不可用，请稍后重试');
+      }
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      if (response.statusCode != 200 || data['success'] != true) {
+        throw const CalendarSubscriptionException('课表订阅操作失败，请稍后重试');
+      }
+      return data;
+    } on CalendarSubscriptionException {
+      rethrow;
+    } catch (_) {
+      throw const CalendarSubscriptionException('无法连接课表订阅服务，请稍后重试');
+    }
+  }
+
+  Future<void> _run(Future<void> Function() action) async {
+    if (_busy) return;
+    _busy = true;
+    _error = null;
+    notifyListeners();
+    try {
+      await action();
+    } catch (e) {
+      _error = e.toString();
+      rethrow;
+    } finally {
+      _busy = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> reload() => _run(() async {
+        final data = (await _send('GET'))['data'];
+        if (data == null) {
+          _record = null;
+        } else {
+          final remote = (data as Map).cast<String, dynamic>();
+          _record = {
+            if (_current?['id'] == remote['id']) ..._current!,
+            ...remote,
+            'primaryId': auth.session!.userId,
+            'api': apiBaseUrl(storage),
+          };
+        }
+        await storage.saveCalendarSubscription(_record);
+      });
+
+  Future<void> publish() => _run(() async {
+        final owner = schedule.owner;
+        final semester = schedule.selectedSemesterId;
+        final table = schedule.courseTable;
+        final termBegin = schedule.termBegin;
+        if (owner == null ||
+            table == null ||
+            termBegin == null ||
+            schedule.error != null ||
+            schedule.loading) {
+          throw const CalendarSubscriptionException('请先成功刷新当前课表');
+        }
+        final calendar = IcsExportService().buildCalendar(
+          table: table,
+          termBegin: termBegin,
+          calendarName:
+              schedule.semesterInfo?.findSemesterLabel(semester ?? '') ?? '课表',
+        );
+        final data = (await _send('PUT', {
+          if (enabled) 'id': _current!['id'],
+          'calendar': calendar,
+        }))['data'] as Map;
+        _record = {
+          ...data.cast<String, dynamic>(),
+          'primaryId': auth.session!.userId,
+          'api': apiBaseUrl(storage),
+          'campusOwner': owner,
+          'semester': semester,
+        };
+        await storage.saveCalendarSubscription(_record);
+      });
+
+  Future<void> revoke() => _run(() async {
+        if (!enabled) return;
+        await _send('DELETE', {'id': _current!['id']});
+        _record = null;
+        await storage.saveCalendarSubscription(null);
+      });
+
+  @override
+  void dispose() {
+    schedule.removeListener(_scheduleChanged);
+    _client.close();
+    super.dispose();
+  }
+}

--- a/lib/services/ics/ics_export_service.dart
+++ b/lib/services/ics/ics_export_service.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 
 import '../../models/course_table.dart';
@@ -108,7 +110,7 @@ class IcsExportService {
     for (final event in _expandCalendarEvents(table, termBegin)) {
       buffer.writeln('BEGIN:VEVENT');
       buffer.writeln(
-        'UID:${_buildUid(event.course, event.week, event.day, event.startPeriodIndex, event.endPeriodIndex)}',
+        'UID:${_buildUid(event.course, event.classDate, event.startPeriodIndex)}',
       );
       buffer.writeln(
         'DTSTAMP:${_formatUtcTimestamp(DateTime.now().toUtc())}',
@@ -139,7 +141,22 @@ class IcsExportService {
     }
 
     buffer.writeln('END:VCALENDAR');
-    return buffer.toString();
+    // RFC 5545 limits content lines to 75 octets, including continuation space.
+    return '${buffer.toString().trimRight().split('\n').map((line) {
+      final folded = StringBuffer();
+      var bytes = 0;
+      for (final rune in line.runes) {
+        final character = String.fromCharCode(rune);
+        final length = utf8.encode(character).length;
+        if (bytes + length > 75) {
+          folded.write('\r\n ');
+          bytes = 1;
+        }
+        folded.write(character);
+        bytes += length;
+      }
+      return folded.toString();
+    }).join('\r\n')}\r\n';
   }
 
   Future<SavedIcsFile> saveCalendar({
@@ -178,13 +195,11 @@ class IcsExportService {
 
   String _buildUid(
     EamsCourse course,
-    int week,
-    int day,
+    DateTime date,
     int startPeriod,
-    int endPeriod,
   ) {
     final seed =
-        '${course.name}-${course.classroom}-$week-$day-$startPeriod-$endPeriod';
+        '${course.name}-${date.year}-${date.month}-${date.day}-$startPeriod';
     return '${Uri.encodeComponent(seed)}@techpie';
   }
 
@@ -257,14 +272,16 @@ class IcsExportService {
 
   String _escapeText(String value) {
     return value
-        .replaceAll(r'', r'')
+        .replaceAll('\\', '\\\\')
         .replaceAll(';', r'\;')
         .replaceAll(',', r'\,')
+        .replaceAll('\r\n', '\n')
+        .replaceAll('\r', '\n')
         .replaceAll('\n', r'\n');
   }
 
   String _escapeAppleText(String value) {
-    return value.replaceAll(r'', r'').replaceAll('"', r'\"');
+    return _escapeText(value).replaceAll('"', r'\"');
   }
 }
 

--- a/lib/services/service_provider.dart
+++ b/lib/services/service_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 
 import 'assignment_service.dart';
 import 'auth_service.dart';
+import 'calendar_subscription_service.dart';
 import 'debug_logger.dart';
 import 'oa_gym_service.dart';
 import 'schedule_service.dart';
@@ -18,6 +19,7 @@ class ServiceProvider extends InheritedWidget {
   final ThemeService themeService;
   final ScheduleService scheduleService;
   final AssignmentService assignmentService;
+  final CalendarSubscriptionService calendarSubscriptionService;
   final ThirdPartyAuthService thirdPartyAuthService;
   final OaGymService oaGymService;
   final UniAuthService uniAuthService;
@@ -31,6 +33,7 @@ class ServiceProvider extends InheritedWidget {
     required this.themeService,
     required this.scheduleService,
     required this.assignmentService,
+    required this.calendarSubscriptionService,
     required this.thirdPartyAuthService,
     required this.oaGymService,
     required this.uniAuthService,
@@ -53,6 +56,7 @@ class ServiceProvider extends InheritedWidget {
       themeService != oldWidget.themeService ||
       scheduleService != oldWidget.scheduleService ||
       assignmentService != oldWidget.assignmentService ||
+      calendarSubscriptionService != oldWidget.calendarSubscriptionService ||
       thirdPartyAuthService != oldWidget.thirdPartyAuthService ||
       oaGymService != oldWidget.oaGymService ||
       uniAuthService != oldWidget.uniAuthService ||

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -35,6 +35,21 @@ class StorageService {
   Future<void> setCampusWebOwner(String owner) =>
       _prefs.setString('campus_web_owner', owner);
 
+  Future<Map<String, dynamic>?> loadCalendarSubscription() async {
+    final raw = await _secure.read(key: 'calendar_subscription');
+    if (raw == null) return null;
+    try {
+      return (jsonDecode(raw) as Map).cast<String, dynamic>();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> saveCalendarSubscription(Map<String, dynamic>? value) => value ==
+          null
+      ? _secure.delete(key: 'calendar_subscription')
+      : _secure.write(key: 'calendar_subscription', value: jsonEncode(value));
+
   // Secure session storage
   Future<void> saveSession(UserSession session) async {
     await _writeCredential(() =>


### PR DESCRIPTION
课表页新增订阅管理：显式确认后上传当前学期 ICS，支持复制链接、交给日历 App 和撤销。之后仅在同一校园账号、同一学期成功刷新时更新快照；页面说明更新条件、链接可读范围与有效期。修正 ICS 转义、UTF-8 折行和事件标识，避免教室变化生成重复事件。

依赖 #93；配套 API：HeZeBang/shanghaitech-cpdaily-auth#11。后端配置部署完成前，入口会提示服务暂不可用。

验证：独立 Flutter analyze、iOS 模拟器构建及本地订阅请求与 ICS 测试通过。线上订阅和日历客户端尚未联调。
